### PR TITLE
Update projection item

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -273,5 +273,34 @@ describe("rhombic", () => {
         "SELECT column01 AS my_column01, column02 AS my_column02, column03, column04 FROM my_table"
       );
     });
+
+    it("should deal with multiple stars query", () => {
+      const query = rhombic
+        .parse("SELECT column01 AS my_column01, *, column04, * FROM my_table")
+        .updateProjectionItem({
+          columns: [
+            "my_column01",
+            // *
+            "column01",
+            "column02",
+            "column03",
+            "column04",
+            // column 04
+            "column040",
+            // *
+            "column010",
+            "column020",
+            "column030",
+            "column041"
+          ],
+          index: 3,
+          value: "column03 AS oh_yeah"
+        })
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT column01 AS my_column01, column01, column02, column03 AS oh_yeah, column04, column04, * FROM my_table"
+      );
+    });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -214,4 +214,64 @@ describe("rhombic", () => {
       expect(query).toEqual('SELECT *, column01 AS toto, "day" FROM my_table');
     });
   });
+
+  describe("updateProjectionItem", () => {
+    it("should rename a simple statement", () => {
+      const query = rhombic
+        .parse("SELECT column01 FROM my_table")
+        .updateProjectionItem({
+          columns: ["column01"],
+          index: 0,
+          value: "column01 AS my_column"
+        })
+        .toString();
+
+      expect(query).toEqual("SELECT column01 AS my_column FROM my_table");
+    });
+
+    it("should expanded a star if needed", () => {
+      const query = rhombic
+        .parse("SELECT * FROM my_table")
+        .updateProjectionItem({
+          columns: ["column01", "column02", "column03", "column04"],
+          index: 1,
+          value: "column02 AS my_column"
+        })
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT column01, column02 AS my_column, column03, column04 FROM my_table"
+      );
+    });
+
+    it("should expanded a star with side projections", () => {
+      const query = rhombic
+        .parse("SELECT column01, *, column04 FROM my_table")
+        .updateProjectionItem({
+          columns: ["column01", "column02", "column03", "column04"],
+          index: 1,
+          value: "column02 AS my_column"
+        })
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT column01, column02 AS my_column, column03, column04 FROM my_table"
+      );
+    });
+
+    it("should preserved previous rename", () => {
+      const query = rhombic
+        .parse("SELECT column01 AS my_column01, *, column04 FROM my_table")
+        .updateProjectionItem({
+          columns: ["my_column01", "column02", "column03", "column04"],
+          index: 1,
+          value: "column02 AS my_column02"
+        })
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT column01 AS my_column01, column02 AS my_column02, column03, column04 FROM my_table"
+      );
+    });
+  });
 });

--- a/src/utils/getLocation.ts
+++ b/src/utils/getLocation.ts
@@ -1,0 +1,26 @@
+import { IToken } from "chevrotain";
+
+/**
+ * Returns the location of a token
+ *
+ * @param token
+ */
+export const getLocation = (
+  token: Pick<IToken, "startColumn" | "endColumn" | "startLine" | "endLine">
+) => {
+  if (
+    token.startLine === undefined ||
+    token.endLine === undefined ||
+    token.startColumn === undefined ||
+    token.endColumn === undefined
+  ) {
+    throw new Error("Token is missing location information");
+  }
+
+  return {
+    startLine: token.startLine!, // Checked in the runtime
+    endLine: token.endLine!, // Checked in the runtime
+    startColumn: token.startColumn!, // Checked in the runtime
+    endColumn: token.endColumn! // Checked in the runtime
+  };
+};

--- a/src/utils/insertText.ts
+++ b/src/utils/insertText.ts
@@ -1,5 +1,5 @@
 /**
- * Insert a piece of text a multiline sql statement.
+ * Insert a piece of text in a multiline sql statement.
  *
  * @param sql initial sql
  * @param input text to insert
@@ -11,22 +11,25 @@ export const insertText = (
   location: { line: number; column: number }
 ) => {
   const lines = sql.split("\n");
-  if (location.line > lines.length) {
+  if (location.line - 1 > lines.length) {
     throw new Error(
-      `Can't insert a text on line ${location.line}, the sql statement has only ${lines.length} lines`
+      `Can't insert a text on line ${location.line -
+        1}, the sql statement has only ${lines.length} lines`
     );
   }
 
-  if (location.column > lines[location.line].length) {
+  if (location.column > lines[location.line - 1].length) {
     throw new Error(
-      `Can't insert a text at ${location.line}:${location.column}, the line has only ${lines[location.line].length} characts`
+      `Can't insert a text at ${location.line - 1}:${
+        location.column
+      }, the line has only ${lines[location.line - 1].length} characts`
     );
   }
 
-  lines[location.line] =
-    lines[location.line].slice(0, location.column) +
+  lines[location.line - 1] =
+    lines[location.line - 1].slice(0, location.column) +
     input +
-    lines[location.line].slice(location.column);
+    lines[location.line - 1].slice(location.column);
 
   return lines.join("\n");
 };

--- a/src/utils/replaceText.test.ts
+++ b/src/utils/replaceText.test.ts
@@ -1,0 +1,57 @@
+import { replaceText } from "./replaceText";
+
+type Tests = Array<{
+  description: string;
+  input: string;
+  location: {
+    startLine: number;
+    endLine: number;
+    startColumn: number;
+    endColumn: number;
+  };
+  value: string;
+  expected: string;
+}>;
+
+describe("replaceText", () => {
+  const tests: Tests = [
+    {
+      description: "simple case",
+      input: `select * from plop`,
+      location: {
+        startLine: 1,
+        endLine: 1,
+        startColumn: 8,
+        endColumn: 8
+      },
+      value: "foo",
+      expected: `select foo from plop`
+    },
+    {
+      description: "multiline case",
+      input: `select
+  a,
+  b,
+  c
+from plop`,
+      location: {
+        startLine: 2,
+        endLine: 4,
+        startColumn: 3,
+        endColumn: 3
+      },
+      value: "foo",
+      expected: `select
+  foo
+from plop`
+    }
+  ];
+
+  tests.forEach(test =>
+    it(`should deal with ${test.description}`, () => {
+      expect(replaceText(test.input, test.value, test.location)).toBe(
+        test.expected
+      );
+    })
+  );
+});

--- a/src/utils/replaceText.ts
+++ b/src/utils/replaceText.ts
@@ -1,0 +1,54 @@
+import { insertText } from "./insertText";
+
+/**
+ * Replace a piece of text in a multine sql statement.
+ * @param sql intial sql
+ * @param input text to insert
+ * @param location
+ */
+export const replaceText = (
+  sql: string,
+  input: string,
+  location: {
+    startLine: number;
+    endLine: number;
+    startColumn: number;
+    endColumn: number;
+  }
+) => {
+  const lines = sql
+    .split("\n")
+    .map((line, lineNumber) => {
+      let nextLine;
+      if (
+        lineNumber === location.startLine - 1 &&
+        location.startLine === location.endLine
+      ) {
+        nextLine =
+          line.slice(0, location.startColumn - 1) +
+          line.slice(location.endColumn);
+      } else if (location.startLine - 1 === lineNumber) {
+        nextLine = line.slice(0, location.startColumn - 1);
+      } else if (location.endLine - 1 === lineNumber) {
+        nextLine = line.slice(location.endColumn);
+      } else if (
+        lineNumber > location.startLine - 1 &&
+        lineNumber < location.endLine - 1
+      ) {
+        nextLine = "";
+      }
+
+      if (nextLine === undefined) {
+        return line;
+      }
+
+      // Filter empty modified lines
+      return nextLine === "" ? false : nextLine;
+    })
+    .filter(line => line !== false);
+
+  return insertText(lines.join("\n"), input, {
+    line: location.startLine,
+    column: location.startColumn - 1
+  });
+};

--- a/src/visitors/ProjectionItemsVisitor.ts
+++ b/src/visitors/ProjectionItemsVisitor.ts
@@ -8,7 +8,16 @@ const Visitor = parser.getBaseCstVisitorConstructorWithDefaults();
  * Visitor to extract `projectionItem` list
  */
 export class ProjectionItemsVisitor extends Visitor {
-  public output: IToken[] = [];
+  public output: Array<{
+    startLine: number;
+    endLine: number;
+    startColumn: number;
+    endColumn: number;
+    isAsterisk: boolean;
+    children: IToken[];
+  }> = [];
+
+  public hasAsterisk = false;
 
   constructor() {
     super();
@@ -16,18 +25,56 @@ export class ProjectionItemsVisitor extends Visitor {
   }
 
   projectionItem(ctx: ProjectionItemContext) {
+    let startLine = Infinity;
+    let endLine = -Infinity;
+    let startColumn = Infinity;
+    let endColumn = -Infinity;
+    let isAsterisk = false;
+    const children: IToken[] = [];
+
     if (ctx.expression) {
       ctx.expression.forEach(i => {
-        Object.values(i.children).forEach(j => this.output.push(...j));
+        Object.values(i.children).forEach(j => {
+          j.map((token: IToken) => {
+            startLine = Math.min(startLine, token.startLine || Infinity);
+            endLine = Math.max(endLine, token.endLine || -Infinity);
+            startColumn = Math.min(startColumn, token.startColumn || Infinity);
+            endColumn = Math.max(endColumn, token.endColumn || -Infinity);
+          });
+          children.push(...j);
+        });
       });
     }
 
     if (ctx.Asterisk) {
-      this.output.push(...ctx.Asterisk);
+      ctx.Asterisk.map(token => {
+        startLine = Math.min(startLine, token.startLine || Infinity);
+        endLine = Math.max(endLine, token.endLine || -Infinity);
+        startColumn = Math.min(startColumn, token.startColumn || Infinity);
+        endColumn = Math.max(endColumn, token.endColumn || -Infinity);
+      });
+      children.push(...ctx.Asterisk);
+      this.hasAsterisk = true;
+      isAsterisk = true;
     }
 
     if (ctx.Identifier) {
-      this.output.push(...ctx.Identifier);
+      ctx.Identifier.map(token => {
+        startLine = Math.min(startLine, token.startLine || Infinity);
+        endLine = Math.max(endLine, token.endLine || -Infinity);
+        startColumn = Math.min(startColumn, token.startColumn || Infinity);
+        endColumn = Math.max(endColumn, token.endColumn || -Infinity);
+      });
+      children.push(...ctx.Identifier);
     }
+
+    this.output.push({
+      startLine,
+      endLine,
+      startColumn,
+      endColumn,
+      isAsterisk,
+      children
+    });
   }
 }

--- a/src/visitors/ProjectionItemsVisitor.ts
+++ b/src/visitors/ProjectionItemsVisitor.ts
@@ -17,7 +17,7 @@ export class ProjectionItemsVisitor extends Visitor {
     children: IToken[];
   }> = [];
 
-  public hasAsterisk = false;
+  public asteriskCount = 0;
 
   constructor() {
     super();
@@ -54,7 +54,7 @@ export class ProjectionItemsVisitor extends Visitor {
         endColumn = Math.max(endColumn, token.endColumn || -Infinity);
       });
       children.push(...ctx.Asterisk);
-      this.hasAsterisk = true;
+      this.asteriskCount++;
       isAsterisk = true;
     }
 


### PR DESCRIPTION
### Summary

Add `updateProjectionItem`.

This method is to support mutation of a resulted projection item, this take the result and the orignal statement to be able to expands `*` if needed.

More details about the usage in the code documentation and unit tests.