### PR TITLE
Deal with `ORDER BY` helper with query including `LIMIT`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhombic",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Apache Calcite SQL parser and associate helpers",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -720,5 +720,14 @@ FROM
         "SELECT * FROM my_db ORDER BY b DESC NULLS LAST, a DESC, c DESC NULLS FIRST"
       );
     });
+
+    it("should update a statement with a LIMIT", () => {
+      const query = rhombic
+        .parse("SELECT * FROM my_db LIMIT 10")
+        .orderBy({ expression: "a" })
+        .toString();
+
+      expect(query).toEqual("SELECT * FROM my_db ORDER BY a LIMIT 10");
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,6 +378,9 @@ const parsedSql = (sql: string): ParsedSql => {
         if (order) orderBy += ` ${order.toUpperCase()}`;
         if (nullsOrder) orderBy += ` NULLS ${nullsOrder.toUpperCase()}`;
 
+        if (visitor.insertLocation) {
+          return parsedSql(insertText(sql, orderBy, visitor.insertLocation));
+        }
         return parsedSql(sql + orderBy);
       } else {
         const existingOrderItem = orderItems.find(

--- a/src/visitors/OrderByVisitor.ts
+++ b/src/visitors/OrderByVisitor.ts
@@ -1,5 +1,5 @@
 import { parser } from "../SqlParser";
-import { OrderItemContext } from "../Context";
+import { OrderItemContext, SelectContext } from "../Context";
 import { getImageFromChildren } from "../utils/getImageFromChildren";
 import { getChildrenRange } from "../utils/getChildrenRange";
 
@@ -20,6 +20,10 @@ interface OrderItem {
  */
 export class OrderByVisitor extends Visitor {
   public output: OrderItem[] = [];
+  /**
+   * Position to insert an ORDER BY statement
+   */
+  public insertLocation?: { line: number; column: number };
 
   constructor() {
     super();
@@ -39,5 +43,13 @@ export class OrderByVisitor extends Visitor {
     if (ctx.Last) item.nullsOrder = "last";
 
     this.output.push(item);
+  }
+
+  select(ctx: SelectContext) {
+    const range = getChildrenRange(ctx);
+    this.insertLocation = {
+      line: range.endLine,
+      column: range.endColumn
+    };
   }
 }


### PR DESCRIPTION
### Summary

The first implementation of appending `ORDER BY` statement at the end of the query works well until we introduce `LIMIT`.

This PR add a bit more logic to inject the `ORDER BY` statement at the correct location (just after the `select` statement)