### PR TITLE
Add `WHERE` grammar and helpers

### DIFF
--- a/docs/diagrams.html
+++ b/docs/diagrams.html
@@ -435,8 +435,259 @@
     {
       type: "Rule",
       name: "valueExpression",
-      orgText: "function () { }",
-      definition: []
+      orgText:
+        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Boolean); } }\r\n            ]);\r\n        }",
+      definition: [
+        {
+          type: "Alternation",
+          idx: 0,
+          definition: [
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "Integer",
+                  label: "Integer",
+                  idx: 0,
+                  pattern: "0|[1-9]\\d*"
+                }
+              ]
+            },
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "String",
+                  label: "String",
+                  idx: 0,
+                  pattern:
+                    "((`[^`]*(`))+)|((\\[[^\\]]*(\\]))(\\][^\\]]*(\\]))*)|((\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*(\"))+)|(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('))+)|((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('))+)"
+                }
+              ]
+            },
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "Boolean",
+                  label: "Boolean",
+                  idx: 0,
+                  pattern: "TRUE|FALSE"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      type: "Rule",
+      name: "booleanExpression",
+      orgText:
+        "function () {\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(LParen);\r\n                        _this.SUBRULE(_this.booleanExpression);\r\n                        _this.CONSUME(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () { return _this.SUBRULE1(_this.booleanExpressionValue); }\r\n                }\r\n            ]);\r\n            _this.OPTION(function () {\r\n                _this.OR1([\r\n                    { ALT: function () { return _this.CONSUME(Or); } },\r\n                    { ALT: function () { return _this.CONSUME(And); } }\r\n                ]);\r\n                _this.SUBRULE2(_this.booleanExpression);\r\n            });\r\n        }",
+      definition: [
+        {
+          type: "Alternation",
+          idx: 0,
+          definition: [
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "LParen",
+                  label: "LParen",
+                  idx: 0,
+                  pattern: "\\("
+                },
+                {
+                  type: "NonTerminal",
+                  name: "booleanExpression",
+                  idx: 0
+                },
+                {
+                  type: "Terminal",
+                  name: "RParen",
+                  label: "RParen",
+                  idx: 0,
+                  pattern: "\\)"
+                }
+              ]
+            },
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "NonTerminal",
+                  name: "booleanExpressionValue",
+                  idx: 1
+                }
+              ]
+            }
+          ]
+        },
+        {
+          type: "Option",
+          idx: 0,
+          definition: [
+            {
+              type: "Alternation",
+              idx: 1,
+              definition: [
+                {
+                  type: "Flat",
+                  definition: [
+                    {
+                      type: "Terminal",
+                      name: "Or",
+                      label: "Or",
+                      idx: 0,
+                      pattern: "OR"
+                    }
+                  ]
+                },
+                {
+                  type: "Flat",
+                  definition: [
+                    {
+                      type: "Terminal",
+                      name: "And",
+                      label: "And",
+                      idx: 0,
+                      pattern: "AND"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              type: "NonTerminal",
+              name: "booleanExpression",
+              idx: 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      type: "Rule",
+      name: "booleanExpressionValue",
+      orgText:
+        "function () {\r\n            _this.CONSUME(Identifier);\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        // Binary operation\r\n                        _this.CONSUME(BinaryOperator);\r\n                        _this.SUBRULE(_this.valueExpression);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Multival operation\r\n                        _this.CONSUME(MultivalOperator);\r\n                        _this.CONSUME1(LParen);\r\n                        _this.AT_LEAST_ONE_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE1(_this.valueExpression); }\r\n                        });\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Unary operation\r\n                        _this.OR2([\r\n                            { ALT: function () { return _this.CONSUME(IsNull); } },\r\n                            { ALT: function () { return _this.CONSUME(IsNotNull); } }\r\n                        ]);\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+      definition: [
+        {
+          type: "Terminal",
+          name: "Identifier",
+          label: "Identifier",
+          idx: 0,
+          pattern: '[a-zA-Z]\\w*|"[^"]*"'
+        },
+        {
+          type: "Alternation",
+          idx: 0,
+          definition: [
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "BinaryOperator",
+                  label: "BinaryOperator",
+                  idx: 0,
+                  pattern: "=|>=?|<=?|\\!="
+                },
+                {
+                  type: "NonTerminal",
+                  name: "valueExpression",
+                  idx: 0
+                }
+              ]
+            },
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "MultivalOperator",
+                  label: "MultivalOperator",
+                  idx: 0,
+                  pattern: "NOT IN|IN|LIKE"
+                },
+                {
+                  type: "Terminal",
+                  name: "LParen",
+                  label: "LParen",
+                  idx: 1,
+                  pattern: "\\("
+                },
+                {
+                  type: "RepetitionMandatoryWithSeparator",
+                  idx: 0,
+                  separator: {
+                    type: "Terminal",
+                    name: "Comma",
+                    label: "Comma",
+                    idx: 1,
+                    pattern: ","
+                  },
+                  definition: [
+                    {
+                      type: "NonTerminal",
+                      name: "valueExpression",
+                      idx: 1
+                    }
+                  ]
+                },
+                {
+                  type: "Terminal",
+                  name: "RParen",
+                  label: "RParen",
+                  idx: 1,
+                  pattern: "\\)"
+                }
+              ]
+            },
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Alternation",
+                  idx: 2,
+                  definition: [
+                    {
+                      type: "Flat",
+                      definition: [
+                        {
+                          type: "Terminal",
+                          name: "IsNull",
+                          label: "IsNull",
+                          idx: 0,
+                          pattern: "IS NULL"
+                        }
+                      ]
+                    },
+                    {
+                      type: "Flat",
+                      definition: [
+                        {
+                          type: "Terminal",
+                          name: "IsNotNull",
+                          label: "IsNotNull",
+                          idx: 0,
+                          pattern: "IS NOT NULL"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
       type: "Rule",
@@ -541,7 +792,7 @@
       type: "Rule",
       name: "select",
       orgText:
-        "function () {\r\n            _this.CONSUME(Select);\r\n            _this.OPTION(function () { return _this.CONSUME(Stream); });\r\n            _this.OPTION1(function () {\r\n                _this.OR([\r\n                    { ALT: function () { return _this.CONSUME(All); } },\r\n                    { ALT: function () { return _this.CONSUME(Distinct); } }\r\n                ]);\r\n            });\r\n            _this.SUBRULE(_this.projectionItems);\r\n            // Everything is wrap into `OPTION` to deal with selectWithoutFrom case\r\n            _this.OPTION3(function () {\r\n                _this.CONSUME(From);\r\n                _this.SUBRULE(_this.tableExpression);\r\n            });\r\n        }",
+        "function () {\r\n            _this.CONSUME(Select);\r\n            _this.OPTION(function () { return _this.CONSUME(Stream); });\r\n            _this.OPTION1(function () {\r\n                _this.OR([\r\n                    { ALT: function () { return _this.CONSUME(All); } },\r\n                    { ALT: function () { return _this.CONSUME(Distinct); } }\r\n                ]);\r\n            });\r\n            _this.SUBRULE(_this.projectionItems);\r\n            // Everything is wrap into `OPTION` to deal with selectWithoutFrom case\r\n            _this.OPTION3(function () {\r\n                _this.CONSUME(From);\r\n                _this.SUBRULE(_this.tableExpression);\r\n            });\r\n            _this.OPTION4(function () {\r\n                _this.CONSUME(Where);\r\n                _this.SUBRULE(_this.booleanExpression);\r\n            });\r\n        }",
       definition: [
         {
           type: "Terminal",
@@ -618,6 +869,24 @@
             {
               type: "NonTerminal",
               name: "tableExpression",
+              idx: 0
+            }
+          ]
+        },
+        {
+          type: "Option",
+          idx: 4,
+          definition: [
+            {
+              type: "Terminal",
+              name: "Where",
+              label: "Where",
+              idx: 0,
+              pattern: "WHERE"
+            },
+            {
+              type: "NonTerminal",
+              name: "booleanExpression",
               idx: 0
             }
           ]

--- a/docs/diagrams.html
+++ b/docs/diagrams.html
@@ -245,7 +245,7 @@
                   name: "Identifier",
                   label: "Identifier",
                   idx: 0,
-                  pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                  pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
                 }
               ]
             },
@@ -436,7 +436,7 @@
       type: "Rule",
       name: "valueExpression",
       orgText:
-        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Boolean); } }\r\n            ]);\r\n        }",
+        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Boolean); } },\r\n                { ALT: function () { return _this.CONSUME(Date); } }\r\n            ]);\r\n        }",
       definition: [
         {
           type: "Alternation",
@@ -476,6 +476,19 @@
                   label: "Boolean",
                   idx: 0,
                   pattern: "TRUE|FALSE"
+                }
+              ]
+            },
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "Date",
+                  label: "Date",
+                  idx: 0,
+                  pattern:
+                    "DATE '\\d{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|3[0-1])'"
                 }
               ]
             }
@@ -583,7 +596,7 @@
           name: "Identifier",
           label: "Identifier",
           idx: 0,
-          pattern: '[a-zA-Z]\\w*|"[^"]*"'
+          pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
         },
         {
           type: "Alternation",
@@ -953,7 +966,7 @@
                       name: "Identifier",
                       label: "Identifier",
                       idx: 0,
-                      pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                      pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
                     }
                   ]
                 }
@@ -1053,7 +1066,7 @@
                       name: "Identifier",
                       label: "Identifier",
                       idx: 1,
-                      pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                      pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
                     },
                     {
                       type: "Terminal",
@@ -1073,7 +1086,7 @@
                       name: "Identifier",
                       label: "Identifier",
                       idx: 3,
-                      pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                      pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
                     },
                     {
                       type: "Terminal",
@@ -1089,7 +1102,7 @@
                   name: "Identifier",
                   label: "Identifier",
                   idx: 4,
-                  pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                  pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
                 }
               ]
             }

--- a/docs/diagrams.html
+++ b/docs/diagrams.html
@@ -610,7 +610,7 @@
                   name: "BinaryOperator",
                   label: "BinaryOperator",
                   idx: 0,
-                  pattern: "=|>=?|<=?|\\!="
+                  pattern: "=|>=?|<=?|\\!=|LIKE"
                 },
                 {
                   type: "NonTerminal",
@@ -627,7 +627,7 @@
                   name: "MultivalOperator",
                   label: "MultivalOperator",
                   idx: 0,
-                  pattern: "NOT IN|IN|LIKE"
+                  pattern: "NOT IN|IN"
                 },
                 {
                   type: "Terminal",

--- a/docs/diagrams.html
+++ b/docs/diagrams.html
@@ -49,7 +49,7 @@
       type: "Rule",
       name: "query",
       orgText:
-        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.SUBRULE(_this.values); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.SUBRULE(_this.select);\r\n                        _this.OPTION(function () {\r\n                            _this.CONSUME(OrderBy);\r\n                            _this.AT_LEAST_ONE_SEP({\r\n                                SEP: Comma,\r\n                                DEF: function () { return _this.SUBRULE(_this.orderItem); }\r\n                            });\r\n                        });\r\n                        _this.OPTION1(function () {\r\n                            _this.CONSUME(Limit);\r\n                            _this.OR1([\r\n                                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                                { ALT: function () { return _this.CONSUME(All); } }\r\n                            ]);\r\n                        });\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.SUBRULE(_this.values); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.SUBRULE(_this.select);\r\n                        _this.OPTION(function () {\r\n                            _this.CONSUME(OrderBy);\r\n                            _this.AT_LEAST_ONE_SEP({\r\n                                SEP: Comma,\r\n                                DEF: function () { return _this.SUBRULE(_this.orderItem); }\r\n                            });\r\n                        });\r\n                        _this.OPTION1(function () {\r\n                            _this.CONSUME(Limit);\r\n                            _this.OR1([\r\n                                { ALT: function () { return _this.CONSUME(IntegerValue); } },\r\n                                { ALT: function () { return _this.CONSUME(All); } }\r\n                            ]);\r\n                        });\r\n                    }\r\n                }\r\n            ]);\r\n        }",
       definition: [
         {
           type: "Alternation",
@@ -124,8 +124,8 @@
                           definition: [
                             {
                               type: "Terminal",
-                              name: "Integer",
-                              label: "Integer",
+                              name: "IntegerValue",
+                              label: "IntegerValue",
                               idx: 0,
                               pattern: "0|[1-9]\\d*"
                             }
@@ -157,7 +157,7 @@
       type: "Rule",
       name: "expression",
       orgText:
-        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Null); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(LParen);\r\n                        _this.MANY_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE(_this.expression); }\r\n                        });\r\n                        _this.CONSUME(RParen);\r\n                    }\r\n                },\r\n                { ALT: function () { return _this.CONSUME(Identifier); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(FunctionIdentifier), _this.CONSUME1(LParen);\r\n                        _this.SUBRULE1(_this.expression);\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () { return _this.SUBRULE(_this.cast); }\r\n                }\r\n            ]);\r\n        }",
+        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(IntegerValue); } },\r\n                { ALT: function () { return _this.CONSUME(StringValue); } },\r\n                { ALT: function () { return _this.CONSUME(Null); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(LParen);\r\n                        _this.MANY_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE(_this.expression); }\r\n                        });\r\n                        _this.CONSUME(RParen);\r\n                    }\r\n                },\r\n                { ALT: function () { return _this.CONSUME(Identifier); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(FunctionIdentifier), _this.CONSUME1(LParen);\r\n                        _this.SUBRULE1(_this.expression);\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () { return _this.SUBRULE(_this.cast); }\r\n                }\r\n            ]);\r\n        }",
       definition: [
         {
           type: "Alternation",
@@ -168,8 +168,8 @@
               definition: [
                 {
                   type: "Terminal",
-                  name: "Integer",
-                  label: "Integer",
+                  name: "IntegerValue",
+                  label: "IntegerValue",
                   idx: 0,
                   pattern: "0|[1-9]\\d*"
                 }
@@ -180,8 +180,8 @@
               definition: [
                 {
                   type: "Terminal",
-                  name: "String",
-                  label: "String",
+                  name: "StringValue",
+                  label: "StringValue",
                   idx: 0,
                   pattern:
                     "((`[^`]*(`))+)|((\\[[^\\]]*(\\]))(\\][^\\]]*(\\]))*)|((\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*(\"))+)|(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('))+)|((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('))+)"
@@ -297,7 +297,7 @@
       type: "Rule",
       name: "cast",
       orgText:
-        "function () {\r\n            _this.CONSUME(Cast);\r\n            _this.CONSUME(LParen);\r\n            _this.SUBRULE(_this.expression);\r\n            _this.CONSUME(As);\r\n            _this.SUBRULE(_this.type);\r\n            _this.OPTION(function () {\r\n                _this.CONSUME1(LParen);\r\n                _this.CONSUME(Integer); // precision\r\n                _this.OPTION1(function () {\r\n                    _this.CONSUME(Comma);\r\n                    _this.CONSUME1(Integer); // scale\r\n                });\r\n                _this.CONSUME1(RParen);\r\n            });\r\n            _this.CONSUME(RParen);\r\n        }",
+        "function () {\r\n            _this.CONSUME(Cast);\r\n            _this.CONSUME(LParen);\r\n            _this.SUBRULE(_this.expression);\r\n            _this.CONSUME(As);\r\n            _this.SUBRULE(_this.type);\r\n            _this.OPTION(function () {\r\n                _this.CONSUME1(LParen);\r\n                _this.CONSUME(IntegerValue); // precision\r\n                _this.OPTION1(function () {\r\n                    _this.CONSUME(Comma);\r\n                    _this.CONSUME1(IntegerValue); // scale\r\n                });\r\n                _this.CONSUME1(RParen);\r\n            });\r\n            _this.CONSUME(RParen);\r\n        }",
       definition: [
         {
           type: "Terminal",
@@ -343,8 +343,8 @@
             },
             {
               type: "Terminal",
-              name: "Integer",
-              label: "Integer",
+              name: "IntegerValue",
+              label: "IntegerValue",
               idx: 0,
               pattern: "0|[1-9]\\d*"
             },
@@ -361,8 +361,8 @@
                 },
                 {
                   type: "Terminal",
-                  name: "Integer",
-                  label: "Integer",
+                  name: "IntegerValue",
+                  label: "IntegerValue",
                   idx: 1,
                   pattern: "0|[1-9]\\d*"
                 }
@@ -436,7 +436,7 @@
       type: "Rule",
       name: "valueExpression",
       orgText:
-        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Boolean); } },\r\n                { ALT: function () { return _this.CONSUME(Date); } }\r\n            ]);\r\n        }",
+        "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(IntegerValue); } },\r\n                { ALT: function () { return _this.CONSUME(StringValue); } },\r\n                { ALT: function () { return _this.CONSUME(BooleanValue); } },\r\n                { ALT: function () { return _this.CONSUME(DateValue); } }\r\n            ]);\r\n        }",
       definition: [
         {
           type: "Alternation",
@@ -447,8 +447,8 @@
               definition: [
                 {
                   type: "Terminal",
-                  name: "Integer",
-                  label: "Integer",
+                  name: "IntegerValue",
+                  label: "IntegerValue",
                   idx: 0,
                   pattern: "0|[1-9]\\d*"
                 }
@@ -459,8 +459,8 @@
               definition: [
                 {
                   type: "Terminal",
-                  name: "String",
-                  label: "String",
+                  name: "StringValue",
+                  label: "StringValue",
                   idx: 0,
                   pattern:
                     "((`[^`]*(`))+)|((\\[[^\\]]*(\\]))(\\][^\\]]*(\\]))*)|((\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*(\"))+)|(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('))+)|((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('))+)"
@@ -472,8 +472,8 @@
               definition: [
                 {
                   type: "Terminal",
-                  name: "Boolean",
-                  label: "Boolean",
+                  name: "BooleanValue",
+                  label: "BooleanValue",
                   idx: 0,
                   pattern: "TRUE|FALSE"
                 }
@@ -484,8 +484,8 @@
               definition: [
                 {
                   type: "Terminal",
-                  name: "Date",
-                  label: "Date",
+                  name: "DateValue",
+                  label: "DateValue",
                   idx: 0,
                   pattern:
                     "DATE '\\d{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|3[0-1])'"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhombic",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Apache Calcite SQL parser and associate helpers",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -72,6 +72,7 @@ export interface ValueExpressionContext {
   Integer?: IToken[];
   String?: IToken[];
   Boolean?: IToken[];
+  Date?: IToken[];
 }
 
 export interface BooleanExpressionContext {

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -88,10 +88,6 @@ export interface BooleanExpressionContext {
   }>;
   Or?: IToken[];
   And?: IToken[];
-  booleanExpression: Array<{
-    name: "booleanExpression";
-    children: BooleanExpressionContext;
-  }>;
 }
 
 export interface BooleanExpressionValueContext {
@@ -103,10 +99,6 @@ export interface BooleanExpressionValueContext {
   }>;
   MultivalOperator?: IToken[];
   LParen?: IToken[];
-  valueExpression: Array<{
-    name: "valueExpression";
-    children: ValueExpressionContext;
-  }>;
   Comma?: IToken[];
   RParen?: IToken[];
   IsNull?: IToken[];

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -68,7 +68,49 @@ export interface TypeContext {
   CollectionTypeName?: IToken[];
 }
 
-export interface ValueExpressionContext {}
+export interface ValueExpressionContext {
+  Integer?: IToken[];
+  String?: IToken[];
+  Boolean?: IToken[];
+}
+
+export interface BooleanExpressionContext {
+  LParen?: IToken[];
+  booleanExpression: Array<{
+    name: "booleanExpression";
+    children: BooleanExpressionContext;
+  }>;
+  RParen?: IToken[];
+  booleanExpressionValue: Array<{
+    name: "booleanExpressionValue";
+    children: BooleanExpressionValueContext;
+  }>;
+  Or?: IToken[];
+  And?: IToken[];
+  booleanExpression: Array<{
+    name: "booleanExpression";
+    children: BooleanExpressionContext;
+  }>;
+}
+
+export interface BooleanExpressionValueContext {
+  Identifier: IToken[];
+  BinaryOperator?: IToken[];
+  valueExpression: Array<{
+    name: "valueExpression";
+    children: ValueExpressionContext;
+  }>;
+  MultivalOperator?: IToken[];
+  LParen?: IToken[];
+  valueExpression: Array<{
+    name: "valueExpression";
+    children: ValueExpressionContext;
+  }>;
+  Comma?: IToken[];
+  RParen?: IToken[];
+  IsNull?: IToken[];
+  IsNotNull?: IToken[];
+}
 
 export interface OrderItemContext {
   expression: Array<{
@@ -95,6 +137,11 @@ export interface SelectContext {
   tableExpression: Array<{
     name: "tableExpression";
     children: TableExpressionContext;
+  }>;
+  Where?: IToken[];
+  booleanExpression: Array<{
+    name: "booleanExpression";
+    children: BooleanExpressionContext;
   }>;
 }
 
@@ -156,6 +203,8 @@ export type IContext =
   | CastContext
   | TypeContext
   | ValueExpressionContext
+  | BooleanExpressionContext
+  | BooleanExpressionValueContext
   | OrderItemContext
   | SelectContext
   | ProjectionItemsContext

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -24,13 +24,13 @@ export interface QueryContext {
   }>;
   Comma?: IToken[];
   Limit?: IToken[];
-  Integer?: IToken[];
+  IntegerValue?: IToken[];
   All?: IToken[];
 }
 
 export interface ExpressionContext {
-  Integer?: IToken[];
-  String?: IToken[];
+  IntegerValue?: IToken[];
+  StringValue?: IToken[];
   Null?: IToken[];
   LParen?: IToken[];
   RParen?: IToken[];
@@ -58,7 +58,7 @@ export interface CastContext {
     name: "type";
     children: TypeContext;
   }>;
-  Integer?: IToken[];
+  IntegerValue?: IToken[];
   Comma?: IToken[];
   RParen?: IToken[];
 }
@@ -69,10 +69,10 @@ export interface TypeContext {
 }
 
 export interface ValueExpressionContext {
-  Integer?: IToken[];
-  String?: IToken[];
-  Boolean?: IToken[];
-  Date?: IToken[];
+  IntegerValue?: IToken[];
+  StringValue?: IToken[];
+  BooleanValue?: IToken[];
+  DateValue?: IToken[];
 }
 
 export interface BooleanExpressionContext {

--- a/src/FilterTree.ts
+++ b/src/FilterTree.ts
@@ -1,0 +1,77 @@
+/**
+ * Filter tree representation.
+ *
+ * For example, the following string:
+ * `tejas = 'chicken' AND slava = 'coffee'`
+ * will be represents with the following object:
+ * ```
+ * [
+ *  {type: "predicate", dimension: "tejas", operator: "=", value: "chicken"},
+ *  {type: "operator", operator: "and"},
+ *  {type: "predicate", dimension: "slava", operator: "=", value: "coffee"}
+ * ]
+ * ```
+ */
+export type FilterTree = FilterTreeNode[];
+
+/**
+ * List of valid operators
+ */
+export type Operator =
+  | "="
+  | ">"
+  | ">="
+  | "<"
+  | "<="
+  | "!="
+  | "is null"
+  | "is not null"
+  | "not in"
+  | "in"
+  | "like";
+
+/**
+ * Predicate node
+ */
+export interface FilterTreePredicateNode {
+  type: "predicate";
+  dimension: string;
+  operator: Operator;
+  value?: string;
+}
+
+/**
+ * Operator node
+ */
+export interface FilterTreeOperatorNode {
+  type: "operator";
+  closeParentheses: number[]; // parenthesis id
+  operator?: "and" | "or";
+  openParentheses: number[]; // parenthesis id
+}
+
+/**
+ * Generic Filter tree node
+ */
+export type FilterTreeNode = FilterTreePredicateNode | FilterTreeOperatorNode;
+
+/**
+ * Returns `true` if the node is an operator.
+ *
+ * @param node
+ */
+export const isOperator = (
+  node: FilterTreeNode
+): node is FilterTreeOperatorNode => {
+  return node.type === "operator";
+};
+
+/**
+ * Returns `true` if the node is a predicate
+ * @param node
+ */
+export const isPredicate = (
+  node: FilterTreeNode
+): node is FilterTreePredicateNode => {
+  return node.type === "predicate";
+};

--- a/src/SqlParser.lexer.test.ts
+++ b/src/SqlParser.lexer.test.ts
@@ -264,6 +264,11 @@ describe("Sql Lexer", () => {
       title: "boolean",
       sql: "true false",
       expected: ["true => Boolean", "false => Boolean"]
+    },
+    {
+      title: "date",
+      sql: "date '2019-02-01'",
+      expected: ["date '2019-02-01' => Date"]
     }
   ];
 

--- a/src/SqlParser.lexer.test.ts
+++ b/src/SqlParser.lexer.test.ts
@@ -236,24 +236,21 @@ describe("Sql Lexer", () => {
     },
     {
       title: "binary operators",
-      sql: "= > >= < <= !=",
+      sql: "= > >= < <= != like",
       expected: [
         "= => BinaryOperator",
         "> => BinaryOperator",
         ">= => BinaryOperator",
         "< => BinaryOperator",
         "<= => BinaryOperator",
-        "!= => BinaryOperator"
+        "!= => BinaryOperator",
+        "like => BinaryOperator"
       ]
     },
     {
       title: "multival operators",
-      sql: "in not in like",
-      expected: [
-        "in => MultivalOperator",
-        "not in => MultivalOperator",
-        "like => MultivalOperator"
-      ]
+      sql: "in not in",
+      expected: ["in => MultivalOperator", "not in => MultivalOperator"]
     },
     {
       title: "unary operators",

--- a/src/SqlParser.lexer.test.ts
+++ b/src/SqlParser.lexer.test.ts
@@ -101,7 +101,7 @@ describe("Sql Lexer", () => {
         "table2 => Identifier",
         "WHERE => Where",
         "column1 => Identifier",
-        "> => Operator",
+        "> => BinaryOperator",
         "42 => Integer"
       ]
     },
@@ -115,11 +115,11 @@ describe("Sql Lexer", () => {
         "table2 => Identifier",
         "WHERE => Where",
         "a => Identifier",
-        "<= => Operator",
+        "<= => BinaryOperator",
         "30 => Integer",
         "AND => And",
         "b => Identifier",
-        ">= => Operator",
+        ">= => BinaryOperator",
         "10 => Integer",
         "OR => Or",
         "c => Identifier",
@@ -237,6 +237,37 @@ describe("Sql Lexer", () => {
       title: "limit",
       sql: "LIMIT 10",
       expected: ["LIMIT => Limit", "10 => Integer"]
+    },
+    {
+      title: "binary operators",
+      sql: "= > >= < <= !=",
+      expected: [
+        "= => BinaryOperator",
+        "> => BinaryOperator",
+        ">= => BinaryOperator",
+        "< => BinaryOperator",
+        "<= => BinaryOperator",
+        "!= => BinaryOperator"
+      ]
+    },
+    {
+      title: "multival operators",
+      sql: "in not in like",
+      expected: [
+        "in => MultivalOperator",
+        "not in => MultivalOperator",
+        "like => MultivalOperator"
+      ]
+    },
+    {
+      title: "unary operators",
+      sql: "is null IS NOT NULL",
+      expected: ["is null => IsNull", "IS NOT NULL => IsNotNull"]
+    },
+    {
+      title: "boolean",
+      sql: "true false",
+      expected: ["true => Boolean", "false => Boolean"]
     }
   ];
 

--- a/src/SqlParser.lexer.test.ts
+++ b/src/SqlParser.lexer.test.ts
@@ -78,15 +78,13 @@ describe("Sql Lexer", () => {
       ]
     },
     {
-      title: "period between two identifier",
+      title: "identifier with dot",
       sql: `SELECT column1 FROM db.table2`,
       expected: [
         "SELECT => Select",
         "column1 => Identifier",
         "FROM => From",
-        "db => Identifier",
-        ". => Period",
-        "table2 => Identifier"
+        "db.table2 => Identifier"
       ]
     },
     {
@@ -96,9 +94,7 @@ describe("Sql Lexer", () => {
         "SELECT => Select",
         "column1 => Identifier",
         "FROM => From",
-        "db => Identifier",
-        ". => Period",
-        "table2 => Identifier",
+        "db.table2 => Identifier",
         "WHERE => Where",
         "column1 => Identifier",
         "> => BinaryOperator",

--- a/src/SqlParser.lexer.test.ts
+++ b/src/SqlParser.lexer.test.ts
@@ -98,7 +98,7 @@ describe("Sql Lexer", () => {
         "WHERE => Where",
         "column1 => Identifier",
         "> => BinaryOperator",
-        "42 => Integer"
+        "42 => IntegerValue"
       ]
     },
     {
@@ -112,11 +112,11 @@ describe("Sql Lexer", () => {
         "WHERE => Where",
         "a => Identifier",
         "<= => BinaryOperator",
-        "30 => Integer",
+        "30 => IntegerValue",
         "AND => And",
         "b => Identifier",
         ">= => BinaryOperator",
-        "10 => Integer",
+        "10 => IntegerValue",
         "OR => Or",
         "c => Identifier",
         "IS NULL => IsNull"
@@ -140,11 +140,11 @@ describe("Sql Lexer", () => {
       sql: `VALUES '1', '2', '3'`,
       expected: [
         "VALUES => Values",
-        "'1' => String",
+        "'1' => StringValue",
         ", => Comma",
-        "'2' => String",
+        "'2' => StringValue",
         ", => Comma",
-        "'3' => String"
+        "'3' => StringValue"
       ]
     },
     {
@@ -185,7 +185,7 @@ describe("Sql Lexer", () => {
         "AS => As",
         "DEC => SqlTypeName",
         "( => LParen",
-        "2 => Integer",
+        "2 => IntegerValue",
         ") => RParen",
         ") => RParen"
       ]
@@ -200,9 +200,9 @@ describe("Sql Lexer", () => {
         "AS => As",
         "DEC => SqlTypeName",
         "( => LParen",
-        "2 => Integer",
+        "2 => IntegerValue",
         ", => Comma",
-        "2 => Integer",
+        "2 => IntegerValue",
         ") => RParen",
         ") => RParen"
       ]
@@ -232,7 +232,7 @@ describe("Sql Lexer", () => {
     {
       title: "limit",
       sql: "LIMIT 10",
-      expected: ["LIMIT => Limit", "10 => Integer"]
+      expected: ["LIMIT => Limit", "10 => IntegerValue"]
     },
     {
       title: "binary operators",
@@ -260,12 +260,12 @@ describe("Sql Lexer", () => {
     {
       title: "boolean",
       sql: "true false",
-      expected: ["true => Boolean", "false => Boolean"]
+      expected: ["true => BooleanValue", "false => BooleanValue"]
     },
     {
       title: "date",
       sql: "date '2019-02-01'",
-      expected: ["date '2019-02-01' => Date"]
+      expected: ["date '2019-02-01' => DateValue"]
     }
   ];
 

--- a/src/SqlParser.parseSql.test.ts
+++ b/src/SqlParser.parseSql.test.ts
@@ -496,6 +496,67 @@ describe("parseSql", () => {
             )
           Comma(",")
         )`
+    },
+    {
+      title: "WHERE",
+      sql: "SELECT * FROM my_db WHERE column1 = 'toto'",
+      expected: `query(
+        select(
+          Select("SELECT")
+          projectionItems(
+            projectionItem(
+              Asterisk("*")
+            )
+          )
+          From("FROM")
+          tableExpression(
+            tableReference(tablePrimary(Identifier("my_db")))
+          )
+          Where("WHERE")
+          booleanExpression(
+            booleanExpressionValue(
+              Identifier("column1")
+              BinaryOperator("=")
+              valueExpression(String("'toto'"))
+            )
+          )
+        )
+      )`
+    },
+    {
+      title: "WHERE with multivalue",
+      sql:
+        "SELECT * FROM \"foodmart\".\"CURRENCY\" WHERE CURRENCY in ('USD', 'Mexican Peso')",
+      expected: `query(
+        select(
+          Select("SELECT")
+          projectionItems(
+            projectionItem(
+              Asterisk("*")
+            )
+          )
+          From("FROM")
+          tableExpression(
+            tableReference(tablePrimary(
+              Identifier(""foodmart"", ""CURRENCY"")
+              Period(".")
+              )
+            )
+          )
+          Where("WHERE")
+          booleanExpression(
+            booleanExpressionValue(
+              Identifier("CURRENCY")
+              MultivalOperator("in")
+              LParen("(")
+              valueExpression(String("'USD'"))
+              valueExpression(String("'Mexican Peso'"))
+              Comma(",")
+              RParen(")")
+            )
+          )
+        )
+      )`
     }
   ];
 

--- a/src/SqlParser.parseSql.test.ts
+++ b/src/SqlParser.parseSql.test.ts
@@ -557,6 +557,58 @@ describe("parseSql", () => {
           )
         )
       )`
+    },
+    {
+      title: "WHERE with multiple conditions",
+      sql:
+        "SELECT * FROM my_db WHERE a in ('USD', 'Mexican Peso') AND (b = 'foo' OR c >= 42)",
+      debug: true,
+      expected: `query(
+        select(
+          Select("SELECT")
+          projectionItems(
+            projectionItem(Asterisk("*"))
+          )
+          From("FROM")
+          tableExpression(
+            tableReference(
+              tablePrimary(Identifier("my_db"))
+            )
+          )
+          Where("WHERE")
+          booleanExpression(
+            booleanExpressionValue(
+              Identifier("a")
+              MultivalOperator("in")
+              LParen("(")
+              valueExpression(String("'USD'"))
+              valueExpression(String("'Mexican Peso'"))
+              Comma(",")
+              RParen(")")
+            )
+            And("AND")
+            booleanExpression(
+              LParen("(")
+              booleanExpression(
+                booleanExpressionValue(
+                  Identifier("b")
+                  BinaryOperator("=")
+                  valueExpression(String("'foo'"))
+                )
+                Or("OR")
+                booleanExpression(
+                  booleanExpressionValue(
+                    Identifier("c")
+                    BinaryOperator(">=")
+                    valueExpression(Integer("42"))
+                  )
+                )
+              )
+              RParen(")")
+            )
+          )
+        )
+      )`
     }
   ];
 
@@ -579,7 +631,7 @@ describe("parseSql", () => {
       // Advanced debug
       if (debug) {
         const previous = require("fs").readFileSync("debug.json", "utf-8");
-        const next = JSON.stringify(result.cst, null, 2);
+        const next = prettifyCst(result.cst.children);
         if (previous !== next) {
           require("fs").writeFileSync("debug.json", next);
         }

--- a/src/SqlParser.parseSql.test.ts
+++ b/src/SqlParser.parseSql.test.ts
@@ -22,8 +22,8 @@ describe("parseSql", () => {
       expected: `query(
         values(
           Values("VALUES")
-          expression(Integer("2"))
-          expression(Integer("3"))
+          expression(IntegerValue("2"))
+          expression(IntegerValue("3"))
           Comma(",")
         )
       )`
@@ -34,8 +34,8 @@ describe("parseSql", () => {
       expected: `query(
         values(
           Values("VALUES")
-          expression(String("'a'"))
-          expression(String("'b'"))
+          expression(StringValue("'a'"))
+          expression(StringValue("'b'"))
           Comma(",")
         )
       )`
@@ -48,8 +48,8 @@ describe("parseSql", () => {
           Values("VALUES")
           expression(
             LParen("(")
-            expression(String("'a'"))
-            expression(String("'b'"))
+            expression(StringValue("'a'"))
+            expression(StringValue("'b'"))
             Comma(",")
             RParen(")")
           )
@@ -65,7 +65,7 @@ describe("parseSql", () => {
           Select("SELECT")
           projectionItems(
             projectionItem(
-              expression(String("'hello'"))
+              expression(StringValue("'hello'"))
             )
           )
         )
@@ -140,7 +140,7 @@ describe("parseSql", () => {
           )
         )
         Limit("LIMIT")
-        Integer("10")
+        IntegerValue("10")
       )`
     },
     {
@@ -511,7 +511,7 @@ describe("parseSql", () => {
             booleanExpressionValue(
               Identifier("column1")
               BinaryOperator("=")
-              valueExpression(String("'toto'"))
+              valueExpression(StringValue("'toto'"))
             )
           )
         )
@@ -543,8 +543,8 @@ describe("parseSql", () => {
               Identifier("CURRENCY")
               MultivalOperator("in")
               LParen("(")
-              valueExpression(String("'USD'"))
-              valueExpression(String("'Mexican Peso'"))
+              valueExpression(StringValue("'USD'"))
+              valueExpression(StringValue("'Mexican Peso'"))
               Comma(",")
               RParen(")")
             )
@@ -574,8 +574,8 @@ describe("parseSql", () => {
               Identifier("a")
               MultivalOperator("in")
               LParen("(")
-              valueExpression(String("'USD'"))
-              valueExpression(String("'Mexican Peso'"))
+              valueExpression(StringValue("'USD'"))
+              valueExpression(StringValue("'Mexican Peso'"))
               Comma(",")
               RParen(")")
             )
@@ -586,14 +586,14 @@ describe("parseSql", () => {
                 booleanExpressionValue(
                   Identifier("b")
                   BinaryOperator("=")
-                  valueExpression(String("'foo'"))
+                  valueExpression(StringValue("'foo'"))
                 )
                 Or("OR")
                 booleanExpression(
                   booleanExpressionValue(
                     Identifier("c")
                     BinaryOperator(">=")
-                    valueExpression(Integer("42"))
+                    valueExpression(IntegerValue("42"))
                   )
                 )
               )

--- a/src/SqlParser.ts
+++ b/src/SqlParser.ts
@@ -179,6 +179,10 @@ const String = createToken({
   name: "String",
   pattern: /((`[^`]*(`))+)|((\[[^\]]*(\]))(\][^\]]*(\]))*)|(("[^"\\]*(?:\\.[^"\\]*)*("))+)|(('[^'\\]*(?:\\.[^'\\]*)*('))+)|((N'[^N'\\]*(?:\\.[^N'\\]*)*('))+)/
 });
+const Date = createToken({
+  name: "Date",
+  pattern: /DATE '\d{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|3[0-1])'/i
+});
 
 const WhiteSpace = createToken({
   name: "WhiteSpace",
@@ -208,6 +212,7 @@ const allTokens = [
   All,
   Stream,
   FunctionIdentifier,
+  Date,
   SqlTypeName,
   CollectionTypeName,
   Cast,
@@ -381,7 +386,8 @@ class SqlParser extends CstParser {
     this.OR([
       { ALT: () => this.CONSUME(Integer) },
       { ALT: () => this.CONSUME(String) },
-      { ALT: () => this.CONSUME(Boolean) }
+      { ALT: () => this.CONSUME(Boolean) },
+      { ALT: () => this.CONSUME(Date) }
     ]);
   });
 

--- a/src/SqlParser.ts
+++ b/src/SqlParser.ts
@@ -3,7 +3,7 @@ import { matchFunctionName } from "./utils/matchFunctionName";
 
 const Identifier = createToken({
   name: "Identifier",
-  pattern: /[a-zA-Z]\w*|"[^"]*"/
+  pattern: /[a-zA-Z][\w\.]*|"[^"]*"/
 });
 
 const FunctionIdentifier = createToken({

--- a/src/SqlParser.ts
+++ b/src/SqlParser.ts
@@ -169,19 +169,22 @@ const MultivalOperator = createToken({
   longer_alt: Identifier
 });
 
-const Boolean = createToken({
-  name: "Boolean",
+const BooleanValue = createToken({
+  name: "BooleanValue",
   pattern: /TRUE|FALSE/i,
   longer_alt: Identifier
 });
 
-const Integer = createToken({ name: "Integer", pattern: /0|[1-9]\d*/ });
-const String = createToken({
-  name: "String",
+const IntegerValue = createToken({
+  name: "IntegerValue",
+  pattern: /0|[1-9]\d*/
+});
+const StringValue = createToken({
+  name: "StringValue",
   pattern: /((`[^`]*(`))+)|((\[[^\]]*(\]))(\][^\]]*(\]))*)|(("[^"\\]*(?:\\.[^"\\]*)*("))+)|(('[^'\\]*(?:\\.[^'\\]*)*('))+)|((N'[^N'\\]*(?:\\.[^N'\\]*)*('))+)/
 });
-const Date = createToken({
-  name: "Date",
+const DateValue = createToken({
+  name: "DateValue",
   pattern: /DATE '\d{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|3[0-1])'/i
 });
 
@@ -213,7 +216,7 @@ const allTokens = [
   All,
   Stream,
   FunctionIdentifier,
-  Date,
+  DateValue,
   SqlTypeName,
   CollectionTypeName,
   Cast,
@@ -223,12 +226,12 @@ const allTokens = [
   Limit,
   MultivalOperator,
   BinaryOperator,
-  Boolean,
+  BooleanValue,
 
   // The Identifier must appear after the keywords because all keywords are valid identifiers.
   Identifier,
-  Integer,
-  String,
+  IntegerValue,
+  StringValue,
 
   Asterisk,
   Column,
@@ -291,7 +294,7 @@ class SqlParser extends CstParser {
           this.OPTION1(() => {
             this.CONSUME(Limit);
             this.OR1([
-              { ALT: () => this.CONSUME(Integer) },
+              { ALT: () => this.CONSUME(IntegerValue) },
               { ALT: () => this.CONSUME(All) }
             ]);
           });
@@ -307,8 +310,8 @@ class SqlParser extends CstParser {
    */
   public expression = this.RULE("expression", () => {
     this.OR([
-      { ALT: () => this.CONSUME(Integer) },
-      { ALT: () => this.CONSUME(String) },
+      { ALT: () => this.CONSUME(IntegerValue) },
+      { ALT: () => this.CONSUME(StringValue) },
       { ALT: () => this.CONSUME(Null) },
       {
         ALT: () => {
@@ -342,10 +345,10 @@ class SqlParser extends CstParser {
     this.SUBRULE(this.type);
     this.OPTION(() => {
       this.CONSUME1(LParen);
-      this.CONSUME(Integer); // precision
+      this.CONSUME(IntegerValue); // precision
       this.OPTION1(() => {
         this.CONSUME(Comma);
-        this.CONSUME1(Integer); // scale
+        this.CONSUME1(IntegerValue); // scale
       });
       this.CONSUME1(RParen);
     });
@@ -385,10 +388,10 @@ class SqlParser extends CstParser {
    */
   public valueExpression = this.RULE("valueExpression", () => {
     this.OR([
-      { ALT: () => this.CONSUME(Integer) },
-      { ALT: () => this.CONSUME(String) },
-      { ALT: () => this.CONSUME(Boolean) },
-      { ALT: () => this.CONSUME(Date) }
+      { ALT: () => this.CONSUME(IntegerValue) },
+      { ALT: () => this.CONSUME(StringValue) },
+      { ALT: () => this.CONSUME(BooleanValue) },
+      { ALT: () => this.CONSUME(DateValue) }
     ]);
   });
 

--- a/src/SqlParser.ts
+++ b/src/SqlParser.ts
@@ -159,12 +159,13 @@ const SemiColumn = createToken({ name: "SemiColumn", pattern: /;/ });
 
 const BinaryOperator = createToken({
   name: "BinaryOperator",
-  pattern: /=|>=?|<=?|\!=/
+  pattern: /=|>=?|<=?|\!=|LIKE/i,
+  longer_alt: Identifier
 });
 
 const MultivalOperator = createToken({
   name: "MultivalOperator",
-  pattern: /NOT IN|IN|LIKE/i,
+  pattern: /NOT IN|IN/i,
   longer_alt: Identifier
 });
 
@@ -221,6 +222,7 @@ const allTokens = [
   First,
   Limit,
   MultivalOperator,
+  BinaryOperator,
   Boolean,
 
   // The Identifier must appear after the keywords because all keywords are valid identifiers.
@@ -236,8 +238,7 @@ const allTokens = [
   LParen,
   RParen,
   Comma,
-  Period,
-  BinaryOperator
+  Period
 ];
 
 // reuse the same lexer instance

--- a/src/index.getFilterTree.test.ts
+++ b/src/index.getFilterTree.test.ts
@@ -1,4 +1,4 @@
-import rhombic from ".";
+import rhombic, { printFilter } from ".";
 import { FilterTree } from "./FilterTree";
 
 describe("getFilterTree", () => {
@@ -297,6 +297,20 @@ describe("getFilterTree", () => {
       ]
     },
     {
+      name: "a filter with like keyword",
+      filter: "customer.name like 'a%'",
+      tree: [
+        { type: "operator", openParentheses: [], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.name",
+          operator: "like",
+          value: "'a%'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [] }
+      ]
+    },
+    {
       name: "an empty filter",
       filter: "",
       tree: []
@@ -312,6 +326,10 @@ describe("getFilterTree", () => {
       const filterTree = rhombic.parse(sql).getFilterTree();
 
       expect(filterTree).toEqual(tree);
+    });
+
+    (only ? it.only : it)(`should print ${name}`, () => {
+      expect(printFilter(tree)).toEqual(filter);
     });
   });
 });

--- a/src/index.getFilterTree.test.ts
+++ b/src/index.getFilterTree.test.ts
@@ -1,0 +1,317 @@
+import rhombic from ".";
+import { FilterTree } from "./FilterTree";
+
+describe("getFilterTree", () => {
+  const cases: Array<{
+    name: string;
+    filter: string;
+    tree: FilterTree;
+    only?: boolean;
+  }> = [
+    {
+      name: "a simple filter",
+      filter: "customer.city = 'Paris'",
+      tree: [
+        { type: "operator", openParentheses: [], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Paris'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [] }
+      ]
+    },
+    {
+      name: "a simple filter (dimension multival operator)",
+      filter: "customer.city in ('Paris', 'Berlin')",
+      tree: [
+        { type: "operator", openParentheses: [], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "in",
+          value: "'Paris', 'Berlin'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [] }
+      ]
+    },
+    {
+      name: "a simple filter (dimension unary operator)",
+      filter: "customer.city is not null",
+      tree: [
+        { type: "operator", openParentheses: [], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "is not null"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [] }
+      ]
+    },
+    {
+      name: "a filter with a `or` operator",
+      filter: "customer.city = 'Paris' or customer.city = 'Berlin'",
+      tree: [
+        { type: "operator", openParentheses: [], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Paris'"
+        },
+        {
+          type: "operator",
+          operator: "or",
+          openParentheses: [],
+          closeParentheses: []
+        },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Berlin'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [] }
+      ]
+    },
+    {
+      name: "a filter with a `and` operator",
+      filter: "customer.city = 'Paris' and customer.city = 'Berlin'",
+      tree: [
+        { type: "operator", openParentheses: [], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Paris'"
+        },
+        {
+          type: "operator",
+          operator: "and",
+          openParentheses: [],
+          closeParentheses: []
+        },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Berlin'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [] }
+      ]
+    },
+    {
+      name: "a filter with a parentheses",
+      filter:
+        "(customer.city = 'Paris' or customer.city = 'Berlin') and product.brand = 'Fabulous'",
+      tree: [
+        { type: "operator", openParentheses: [0], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Paris'"
+        },
+        {
+          type: "operator",
+          operator: "or",
+          openParentheses: [],
+          closeParentheses: []
+        },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Berlin'"
+        },
+        {
+          type: "operator",
+          openParentheses: [],
+          closeParentheses: [0],
+          operator: "and"
+        },
+        {
+          type: "predicate",
+          dimension: "product.brand",
+          operator: "=",
+          value: "'Fabulous'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [] }
+      ]
+    },
+    {
+      name: "a filter with a nested parentheses",
+      filter:
+        "((customer.city = 'Paris' or customer.city = 'Berlin') and product.brand = 'Fabulous')",
+      tree: [
+        { type: "operator", openParentheses: [1, 0], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Paris'"
+        },
+        {
+          type: "operator",
+          operator: "or",
+          openParentheses: [],
+          closeParentheses: []
+        },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Berlin'"
+        },
+        {
+          type: "operator",
+          openParentheses: [],
+          closeParentheses: [0],
+          operator: "and"
+        },
+        {
+          type: "predicate",
+          dimension: "product.brand",
+          operator: "=",
+          value: "'Fabulous'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [1] }
+      ]
+    },
+    {
+      name: "a filter with parentheses on the second group",
+      filter:
+        "customer.city = 'Paris' and (customer.city = 'Berlin' and product.brand = 'Fabulous')",
+      tree: [
+        { type: "operator", openParentheses: [], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Paris'"
+        },
+        {
+          type: "operator",
+          openParentheses: [0],
+          closeParentheses: [],
+          operator: "and"
+        },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Berlin'"
+        },
+        {
+          type: "operator",
+          operator: "and",
+          openParentheses: [],
+          closeParentheses: []
+        },
+        {
+          type: "predicate",
+          dimension: "product.brand",
+          operator: "=",
+          value: "'Fabulous'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [0] }
+      ]
+    },
+    {
+      name: "a filter with a multiple parentheses",
+      filter:
+        "(customer.city = 'Paris' or customer.city = 'Berlin') and (product.brand = 'Fabulous')",
+      tree: [
+        { type: "operator", openParentheses: [0], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Paris'"
+        },
+        {
+          type: "operator",
+          operator: "or",
+          openParentheses: [],
+          closeParentheses: []
+        },
+        {
+          type: "predicate",
+          dimension: "customer.city",
+          operator: "=",
+          value: "'Berlin'"
+        },
+        {
+          type: "operator",
+          closeParentheses: [0],
+          openParentheses: [1],
+          operator: "and"
+        },
+        {
+          type: "predicate",
+          dimension: "product.brand",
+          operator: "=",
+          value: "'Fabulous'"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [1] }
+      ]
+    },
+    {
+      name: "a filter with non string values",
+      filter:
+        "(customer.count = 2 or customer.birthdate = date '2019-02-01') and (product.awesome = true)",
+      tree: [
+        { type: "operator", openParentheses: [0], closeParentheses: [] },
+        {
+          type: "predicate",
+          dimension: "customer.count",
+          operator: "=",
+          value: "2"
+        },
+        {
+          type: "operator",
+          operator: "or",
+          openParentheses: [],
+          closeParentheses: []
+        },
+        {
+          type: "predicate",
+          dimension: "customer.birthdate",
+          operator: "=",
+          value: "date '2019-02-01'"
+        },
+        {
+          type: "operator",
+          closeParentheses: [0],
+          openParentheses: [1],
+          operator: "and"
+        },
+        {
+          type: "predicate",
+          dimension: "product.awesome",
+          operator: "=",
+          value: "true"
+        },
+        { type: "operator", openParentheses: [], closeParentheses: [1] }
+      ]
+    },
+    {
+      name: "an empty filter",
+      filter: "",
+      tree: []
+    }
+  ];
+
+  cases.forEach(({ filter, tree, only, name }) => {
+    (only ? it.only : it)(`should parse ${name}`, () => {
+      const sql = filter
+        ? `SELECT * FROM my_db WHERE ${filter}`
+        : `SELECT * FROM my_db`;
+
+      const filterTree = rhombic.parse(sql).getFilterTree();
+
+      expect(filterTree).toEqual(tree);
+    });
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import rhombic from "./";
+import { FilterTree } from "./FilterTree";
 
 describe("rhombic", () => {
   describe("errors", () => {
@@ -728,6 +729,81 @@ FROM
         .toString();
 
       expect(query).toEqual("SELECT * FROM my_db ORDER BY a LIMIT 10");
+    });
+  });
+
+  describe("getFilterString", () => {
+    it("should return an empty string if no filter", () => {
+      const filter = rhombic.parse("SELECT * FROM foo").getFilterString();
+      expect(filter).toEqual("");
+    });
+
+    it("should return the filter string", () => {
+      const filter = rhombic
+        .parse(
+          "SELECT * FROM foo WHERE name = 'tejas' AND chicken LIKE 'crispy' LIMIT 10"
+        )
+        .getFilterString();
+      expect(filter).toEqual("name = 'tejas' AND chicken LIKE 'crispy'");
+    });
+  });
+
+  describe("updateFilter", () => {
+    const filterTree: FilterTree = [
+      { type: "operator", openParentheses: [], closeParentheses: [] },
+      {
+        type: "predicate",
+        dimension: "customer.city",
+        operator: "=",
+        value: "'Paris'"
+      },
+      { type: "operator", openParentheses: [], closeParentheses: [] }
+    ];
+
+    const filterString = "chicken LIKE 'crispy'";
+
+    it("should add a filter from a tree", () => {
+      const query = rhombic
+        .parse("SELECT * FROM my_db")
+        .updateFilter(filterTree)
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT * FROM my_db WHERE customer.city = 'Paris'"
+      );
+    });
+
+    it("should add a filter from a string", () => {
+      const query = rhombic
+        .parse("SELECT * FROM my_db LIMIT 42")
+        .updateFilter(filterString)
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT * FROM my_db WHERE chicken LIKE 'crispy' LIMIT 42"
+      );
+    });
+
+    it("should update a filter from a tree", () => {
+      const query = rhombic
+        .parse("SELECT * FROM my_db WHERE foo = 42")
+        .updateFilter(filterTree)
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT * FROM my_db WHERE customer.city = 'Paris'"
+      );
+    });
+
+    it("should update a filter from a string", () => {
+      const query = rhombic
+        .parse("SELECT * FROM my_db WHERE chicken != 'fresh' LIMIT 42")
+        .updateFilter(filterString)
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT * FROM my_db WHERE chicken LIKE 'crispy' LIMIT 42"
+      );
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,14 @@ import { HasTablePrimary } from "./visitors/HasTablePrimaryVisitor";
 import { replaceText } from "./utils/replaceText";
 import { getLocation } from "./utils/getLocation";
 import { needToBeEscaped } from "./utils/needToBeEscaped";
+import { printFilter } from "./utils/printFilter";
 import { getText } from "./utils/getText";
 import { OrderByVisitor } from "./visitors/OrderByVisitor";
 import { FilterTree } from "./FilterTree";
 import { FilterTreeVisitor } from "./visitors/FilterTreeVisitor";
 
 // Utils
-export { needToBeEscaped };
+export { needToBeEscaped, printFilter };
 
 const rhombic = {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { getLocation } from "./utils/getLocation";
 import { needToBeEscaped } from "./utils/needToBeEscaped";
 import { getText } from "./utils/getText";
 import { OrderByVisitor } from "./visitors/OrderByVisitor";
+import { FilterTree } from "./FilterTree";
+import { FilterTreeVisitor } from "./visitors/FilterTreeVisitor";
 
 // Utils
 export { needToBeEscaped };
@@ -119,6 +121,11 @@ export interface ParsedSql {
     order?: "asc" | "desc";
     nullsOrder?: "last" | "first";
   }): ParsedSql;
+
+  /**
+   * Retrieve a UI friendly object that represent the current filter (`WHERE` statement)
+   */
+  getFilterTree(): FilterTree;
 }
 
 /**
@@ -422,6 +429,12 @@ const parsedSql = (sql: string): ParsedSql => {
           return parsedSql(nextSql);
         }
       }
+    },
+
+    getFilterTree() {
+      const visitor = new FilterTreeVisitor();
+      visitor.visit(cst);
+      return visitor.tree.length > 1 ? visitor.tree : [];
     }
   };
 };

--- a/src/scripts/generateContextTypes.ts
+++ b/src/scripts/generateContextTypes.ts
@@ -154,7 +154,7 @@ function generateDefinitionTypes(
           const entries = new Set();
           return "\n" + isTerminalOnly
             ? node.definition
-                .map(i => generateDefinitionTypes(i.definition, 0, true))
+                .map(i => generateDefinitionTypes(i.definition, 0, true, keys))
                 .join("")
                 .split("\n")
                 .filter((j: string) => {

--- a/src/serializedGrammar.ts
+++ b/src/serializedGrammar.ts
@@ -225,7 +225,7 @@ export const serializedGrammar = [
                 name: "Identifier",
                 label: "Identifier",
                 idx: 0,
-                pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
               }
             ]
           },
@@ -416,7 +416,7 @@ export const serializedGrammar = [
     type: "Rule",
     name: "valueExpression",
     orgText:
-      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Boolean); } }\r\n            ]);\r\n        }",
+      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Boolean); } },\r\n                { ALT: function () { return _this.CONSUME(Date); } }\r\n            ]);\r\n        }",
     definition: [
       {
         type: "Alternation",
@@ -456,6 +456,19 @@ export const serializedGrammar = [
                 label: "Boolean",
                 idx: 0,
                 pattern: "TRUE|FALSE"
+              }
+            ]
+          },
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "Date",
+                label: "Date",
+                idx: 0,
+                pattern:
+                  "DATE '\\d{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|3[0-1])'"
               }
             ]
           }
@@ -563,7 +576,7 @@ export const serializedGrammar = [
         name: "Identifier",
         label: "Identifier",
         idx: 0,
-        pattern: '[a-zA-Z]\\w*|"[^"]*"'
+        pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
       },
       {
         type: "Alternation",
@@ -933,7 +946,7 @@ export const serializedGrammar = [
                     name: "Identifier",
                     label: "Identifier",
                     idx: 0,
-                    pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                    pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
                   }
                 ]
               }
@@ -1033,7 +1046,7 @@ export const serializedGrammar = [
                     name: "Identifier",
                     label: "Identifier",
                     idx: 1,
-                    pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                    pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
                   },
                   {
                     type: "Terminal",
@@ -1053,7 +1066,7 @@ export const serializedGrammar = [
                     name: "Identifier",
                     label: "Identifier",
                     idx: 3,
-                    pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                    pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
                   },
                   {
                     type: "Terminal",
@@ -1069,7 +1082,7 @@ export const serializedGrammar = [
                 name: "Identifier",
                 label: "Identifier",
                 idx: 4,
-                pattern: '[a-zA-Z]\\w*|"[^"]*"'
+                pattern: '[a-zA-Z][\\w\\.]*|"[^"]*"'
               }
             ]
           }

--- a/src/serializedGrammar.ts
+++ b/src/serializedGrammar.ts
@@ -590,7 +590,7 @@ export const serializedGrammar = [
                 name: "BinaryOperator",
                 label: "BinaryOperator",
                 idx: 0,
-                pattern: "=|>=?|<=?|\\!="
+                pattern: "=|>=?|<=?|\\!=|LIKE"
               },
               {
                 type: "NonTerminal",
@@ -607,7 +607,7 @@ export const serializedGrammar = [
                 name: "MultivalOperator",
                 label: "MultivalOperator",
                 idx: 0,
-                pattern: "NOT IN|IN|LIKE"
+                pattern: "NOT IN|IN"
               },
               {
                 type: "Terminal",

--- a/src/serializedGrammar.ts
+++ b/src/serializedGrammar.ts
@@ -29,7 +29,7 @@ export const serializedGrammar = [
     type: "Rule",
     name: "query",
     orgText:
-      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.SUBRULE(_this.values); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.SUBRULE(_this.select);\r\n                        _this.OPTION(function () {\r\n                            _this.CONSUME(OrderBy);\r\n                            _this.AT_LEAST_ONE_SEP({\r\n                                SEP: Comma,\r\n                                DEF: function () { return _this.SUBRULE(_this.orderItem); }\r\n                            });\r\n                        });\r\n                        _this.OPTION1(function () {\r\n                            _this.CONSUME(Limit);\r\n                            _this.OR1([\r\n                                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                                { ALT: function () { return _this.CONSUME(All); } }\r\n                            ]);\r\n                        });\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.SUBRULE(_this.values); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.SUBRULE(_this.select);\r\n                        _this.OPTION(function () {\r\n                            _this.CONSUME(OrderBy);\r\n                            _this.AT_LEAST_ONE_SEP({\r\n                                SEP: Comma,\r\n                                DEF: function () { return _this.SUBRULE(_this.orderItem); }\r\n                            });\r\n                        });\r\n                        _this.OPTION1(function () {\r\n                            _this.CONSUME(Limit);\r\n                            _this.OR1([\r\n                                { ALT: function () { return _this.CONSUME(IntegerValue); } },\r\n                                { ALT: function () { return _this.CONSUME(All); } }\r\n                            ]);\r\n                        });\r\n                    }\r\n                }\r\n            ]);\r\n        }",
     definition: [
       {
         type: "Alternation",
@@ -104,8 +104,8 @@ export const serializedGrammar = [
                         definition: [
                           {
                             type: "Terminal",
-                            name: "Integer",
-                            label: "Integer",
+                            name: "IntegerValue",
+                            label: "IntegerValue",
                             idx: 0,
                             pattern: "0|[1-9]\\d*"
                           }
@@ -137,7 +137,7 @@ export const serializedGrammar = [
     type: "Rule",
     name: "expression",
     orgText:
-      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Null); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(LParen);\r\n                        _this.MANY_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE(_this.expression); }\r\n                        });\r\n                        _this.CONSUME(RParen);\r\n                    }\r\n                },\r\n                { ALT: function () { return _this.CONSUME(Identifier); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(FunctionIdentifier), _this.CONSUME1(LParen);\r\n                        _this.SUBRULE1(_this.expression);\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () { return _this.SUBRULE(_this.cast); }\r\n                }\r\n            ]);\r\n        }",
+      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(IntegerValue); } },\r\n                { ALT: function () { return _this.CONSUME(StringValue); } },\r\n                { ALT: function () { return _this.CONSUME(Null); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(LParen);\r\n                        _this.MANY_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE(_this.expression); }\r\n                        });\r\n                        _this.CONSUME(RParen);\r\n                    }\r\n                },\r\n                { ALT: function () { return _this.CONSUME(Identifier); } },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(FunctionIdentifier), _this.CONSUME1(LParen);\r\n                        _this.SUBRULE1(_this.expression);\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () { return _this.SUBRULE(_this.cast); }\r\n                }\r\n            ]);\r\n        }",
     definition: [
       {
         type: "Alternation",
@@ -148,8 +148,8 @@ export const serializedGrammar = [
             definition: [
               {
                 type: "Terminal",
-                name: "Integer",
-                label: "Integer",
+                name: "IntegerValue",
+                label: "IntegerValue",
                 idx: 0,
                 pattern: "0|[1-9]\\d*"
               }
@@ -160,8 +160,8 @@ export const serializedGrammar = [
             definition: [
               {
                 type: "Terminal",
-                name: "String",
-                label: "String",
+                name: "StringValue",
+                label: "StringValue",
                 idx: 0,
                 pattern:
                   "((`[^`]*(`))+)|((\\[[^\\]]*(\\]))(\\][^\\]]*(\\]))*)|((\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*(\"))+)|(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('))+)|((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('))+)"
@@ -277,7 +277,7 @@ export const serializedGrammar = [
     type: "Rule",
     name: "cast",
     orgText:
-      "function () {\r\n            _this.CONSUME(Cast);\r\n            _this.CONSUME(LParen);\r\n            _this.SUBRULE(_this.expression);\r\n            _this.CONSUME(As);\r\n            _this.SUBRULE(_this.type);\r\n            _this.OPTION(function () {\r\n                _this.CONSUME1(LParen);\r\n                _this.CONSUME(Integer); // precision\r\n                _this.OPTION1(function () {\r\n                    _this.CONSUME(Comma);\r\n                    _this.CONSUME1(Integer); // scale\r\n                });\r\n                _this.CONSUME1(RParen);\r\n            });\r\n            _this.CONSUME(RParen);\r\n        }",
+      "function () {\r\n            _this.CONSUME(Cast);\r\n            _this.CONSUME(LParen);\r\n            _this.SUBRULE(_this.expression);\r\n            _this.CONSUME(As);\r\n            _this.SUBRULE(_this.type);\r\n            _this.OPTION(function () {\r\n                _this.CONSUME1(LParen);\r\n                _this.CONSUME(IntegerValue); // precision\r\n                _this.OPTION1(function () {\r\n                    _this.CONSUME(Comma);\r\n                    _this.CONSUME1(IntegerValue); // scale\r\n                });\r\n                _this.CONSUME1(RParen);\r\n            });\r\n            _this.CONSUME(RParen);\r\n        }",
     definition: [
       {
         type: "Terminal",
@@ -323,8 +323,8 @@ export const serializedGrammar = [
           },
           {
             type: "Terminal",
-            name: "Integer",
-            label: "Integer",
+            name: "IntegerValue",
+            label: "IntegerValue",
             idx: 0,
             pattern: "0|[1-9]\\d*"
           },
@@ -341,8 +341,8 @@ export const serializedGrammar = [
               },
               {
                 type: "Terminal",
-                name: "Integer",
-                label: "Integer",
+                name: "IntegerValue",
+                label: "IntegerValue",
                 idx: 1,
                 pattern: "0|[1-9]\\d*"
               }
@@ -416,7 +416,7 @@ export const serializedGrammar = [
     type: "Rule",
     name: "valueExpression",
     orgText:
-      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Boolean); } },\r\n                { ALT: function () { return _this.CONSUME(Date); } }\r\n            ]);\r\n        }",
+      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(IntegerValue); } },\r\n                { ALT: function () { return _this.CONSUME(StringValue); } },\r\n                { ALT: function () { return _this.CONSUME(BooleanValue); } },\r\n                { ALT: function () { return _this.CONSUME(DateValue); } }\r\n            ]);\r\n        }",
     definition: [
       {
         type: "Alternation",
@@ -427,8 +427,8 @@ export const serializedGrammar = [
             definition: [
               {
                 type: "Terminal",
-                name: "Integer",
-                label: "Integer",
+                name: "IntegerValue",
+                label: "IntegerValue",
                 idx: 0,
                 pattern: "0|[1-9]\\d*"
               }
@@ -439,8 +439,8 @@ export const serializedGrammar = [
             definition: [
               {
                 type: "Terminal",
-                name: "String",
-                label: "String",
+                name: "StringValue",
+                label: "StringValue",
                 idx: 0,
                 pattern:
                   "((`[^`]*(`))+)|((\\[[^\\]]*(\\]))(\\][^\\]]*(\\]))*)|((\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*(\"))+)|(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('))+)|((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('))+)"
@@ -452,8 +452,8 @@ export const serializedGrammar = [
             definition: [
               {
                 type: "Terminal",
-                name: "Boolean",
-                label: "Boolean",
+                name: "BooleanValue",
+                label: "BooleanValue",
                 idx: 0,
                 pattern: "TRUE|FALSE"
               }
@@ -464,8 +464,8 @@ export const serializedGrammar = [
             definition: [
               {
                 type: "Terminal",
-                name: "Date",
-                label: "Date",
+                name: "DateValue",
+                label: "DateValue",
                 idx: 0,
                 pattern:
                   "DATE '\\d{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|3[0-1])'"

--- a/src/serializedGrammar.ts
+++ b/src/serializedGrammar.ts
@@ -415,8 +415,259 @@ export const serializedGrammar = [
   {
     type: "Rule",
     name: "valueExpression",
-    orgText: "function () { }",
-    definition: []
+    orgText:
+      "function () {\r\n            _this.OR([\r\n                { ALT: function () { return _this.CONSUME(Integer); } },\r\n                { ALT: function () { return _this.CONSUME(String); } },\r\n                { ALT: function () { return _this.CONSUME(Boolean); } }\r\n            ]);\r\n        }",
+    definition: [
+      {
+        type: "Alternation",
+        idx: 0,
+        definition: [
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "Integer",
+                label: "Integer",
+                idx: 0,
+                pattern: "0|[1-9]\\d*"
+              }
+            ]
+          },
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "String",
+                label: "String",
+                idx: 0,
+                pattern:
+                  "((`[^`]*(`))+)|((\\[[^\\]]*(\\]))(\\][^\\]]*(\\]))*)|((\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*(\"))+)|(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('))+)|((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('))+)"
+              }
+            ]
+          },
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "Boolean",
+                label: "Boolean",
+                idx: 0,
+                pattern: "TRUE|FALSE"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    type: "Rule",
+    name: "booleanExpression",
+    orgText:
+      "function () {\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(LParen);\r\n                        _this.SUBRULE(_this.booleanExpression);\r\n                        _this.CONSUME(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () { return _this.SUBRULE1(_this.booleanExpressionValue); }\r\n                }\r\n            ]);\r\n            _this.OPTION(function () {\r\n                _this.OR1([\r\n                    { ALT: function () { return _this.CONSUME(Or); } },\r\n                    { ALT: function () { return _this.CONSUME(And); } }\r\n                ]);\r\n                _this.SUBRULE2(_this.booleanExpression);\r\n            });\r\n        }",
+    definition: [
+      {
+        type: "Alternation",
+        idx: 0,
+        definition: [
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "LParen",
+                label: "LParen",
+                idx: 0,
+                pattern: "\\("
+              },
+              {
+                type: "NonTerminal",
+                name: "booleanExpression",
+                idx: 0
+              },
+              {
+                type: "Terminal",
+                name: "RParen",
+                label: "RParen",
+                idx: 0,
+                pattern: "\\)"
+              }
+            ]
+          },
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "NonTerminal",
+                name: "booleanExpressionValue",
+                idx: 1
+              }
+            ]
+          }
+        ]
+      },
+      {
+        type: "Option",
+        idx: 0,
+        definition: [
+          {
+            type: "Alternation",
+            idx: 1,
+            definition: [
+              {
+                type: "Flat",
+                definition: [
+                  {
+                    type: "Terminal",
+                    name: "Or",
+                    label: "Or",
+                    idx: 0,
+                    pattern: "OR"
+                  }
+                ]
+              },
+              {
+                type: "Flat",
+                definition: [
+                  {
+                    type: "Terminal",
+                    name: "And",
+                    label: "And",
+                    idx: 0,
+                    pattern: "AND"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            type: "NonTerminal",
+            name: "booleanExpression",
+            idx: 2
+          }
+        ]
+      }
+    ]
+  },
+  {
+    type: "Rule",
+    name: "booleanExpressionValue",
+    orgText:
+      "function () {\r\n            _this.CONSUME(Identifier);\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        // Binary operation\r\n                        _this.CONSUME(BinaryOperator);\r\n                        _this.SUBRULE(_this.valueExpression);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Multival operation\r\n                        _this.CONSUME(MultivalOperator);\r\n                        _this.CONSUME1(LParen);\r\n                        _this.AT_LEAST_ONE_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE1(_this.valueExpression); }\r\n                        });\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Unary operation\r\n                        _this.OR2([\r\n                            { ALT: function () { return _this.CONSUME(IsNull); } },\r\n                            { ALT: function () { return _this.CONSUME(IsNotNull); } }\r\n                        ]);\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+    definition: [
+      {
+        type: "Terminal",
+        name: "Identifier",
+        label: "Identifier",
+        idx: 0,
+        pattern: '[a-zA-Z]\\w*|"[^"]*"'
+      },
+      {
+        type: "Alternation",
+        idx: 0,
+        definition: [
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "BinaryOperator",
+                label: "BinaryOperator",
+                idx: 0,
+                pattern: "=|>=?|<=?|\\!="
+              },
+              {
+                type: "NonTerminal",
+                name: "valueExpression",
+                idx: 0
+              }
+            ]
+          },
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "MultivalOperator",
+                label: "MultivalOperator",
+                idx: 0,
+                pattern: "NOT IN|IN|LIKE"
+              },
+              {
+                type: "Terminal",
+                name: "LParen",
+                label: "LParen",
+                idx: 1,
+                pattern: "\\("
+              },
+              {
+                type: "RepetitionMandatoryWithSeparator",
+                idx: 0,
+                separator: {
+                  type: "Terminal",
+                  name: "Comma",
+                  label: "Comma",
+                  idx: 1,
+                  pattern: ","
+                },
+                definition: [
+                  {
+                    type: "NonTerminal",
+                    name: "valueExpression",
+                    idx: 1
+                  }
+                ]
+              },
+              {
+                type: "Terminal",
+                name: "RParen",
+                label: "RParen",
+                idx: 1,
+                pattern: "\\)"
+              }
+            ]
+          },
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Alternation",
+                idx: 2,
+                definition: [
+                  {
+                    type: "Flat",
+                    definition: [
+                      {
+                        type: "Terminal",
+                        name: "IsNull",
+                        label: "IsNull",
+                        idx: 0,
+                        pattern: "IS NULL"
+                      }
+                    ]
+                  },
+                  {
+                    type: "Flat",
+                    definition: [
+                      {
+                        type: "Terminal",
+                        name: "IsNotNull",
+                        label: "IsNotNull",
+                        idx: 0,
+                        pattern: "IS NOT NULL"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     type: "Rule",
@@ -521,7 +772,7 @@ export const serializedGrammar = [
     type: "Rule",
     name: "select",
     orgText:
-      "function () {\r\n            _this.CONSUME(Select);\r\n            _this.OPTION(function () { return _this.CONSUME(Stream); });\r\n            _this.OPTION1(function () {\r\n                _this.OR([\r\n                    { ALT: function () { return _this.CONSUME(All); } },\r\n                    { ALT: function () { return _this.CONSUME(Distinct); } }\r\n                ]);\r\n            });\r\n            _this.SUBRULE(_this.projectionItems);\r\n            // Everything is wrap into `OPTION` to deal with selectWithoutFrom case\r\n            _this.OPTION3(function () {\r\n                _this.CONSUME(From);\r\n                _this.SUBRULE(_this.tableExpression);\r\n            });\r\n        }",
+      "function () {\r\n            _this.CONSUME(Select);\r\n            _this.OPTION(function () { return _this.CONSUME(Stream); });\r\n            _this.OPTION1(function () {\r\n                _this.OR([\r\n                    { ALT: function () { return _this.CONSUME(All); } },\r\n                    { ALT: function () { return _this.CONSUME(Distinct); } }\r\n                ]);\r\n            });\r\n            _this.SUBRULE(_this.projectionItems);\r\n            // Everything is wrap into `OPTION` to deal with selectWithoutFrom case\r\n            _this.OPTION3(function () {\r\n                _this.CONSUME(From);\r\n                _this.SUBRULE(_this.tableExpression);\r\n            });\r\n            _this.OPTION4(function () {\r\n                _this.CONSUME(Where);\r\n                _this.SUBRULE(_this.booleanExpression);\r\n            });\r\n        }",
     definition: [
       {
         type: "Terminal",
@@ -598,6 +849,24 @@ export const serializedGrammar = [
           {
             type: "NonTerminal",
             name: "tableExpression",
+            idx: 0
+          }
+        ]
+      },
+      {
+        type: "Option",
+        idx: 4,
+        definition: [
+          {
+            type: "Terminal",
+            name: "Where",
+            label: "Where",
+            idx: 0,
+            pattern: "WHERE"
+          },
+          {
+            type: "NonTerminal",
+            name: "booleanExpression",
             idx: 0
           }
         ]

--- a/src/utils/prettifyCst.ts
+++ b/src/utils/prettifyCst.ts
@@ -1,0 +1,25 @@
+import { CstChildrenDictionary } from "chevrotain";
+import { isCstNode } from "./isCstNode";
+
+/**
+ * Pretty output for cst for easy specifications
+ *
+ * @param cst
+ */
+export function prettifyCst(cst: CstChildrenDictionary) {
+  let output = "";
+  Object.entries(cst).forEach(([_, elements]) => {
+    elements.forEach((node, i, nodes) => {
+      if (isCstNode(node)) {
+        output += node.name + "(" + prettifyCst(node.children) + ")";
+      } else {
+        if (i === 0 && node.tokenType) output += node.tokenType.tokenName;
+        if (i === 0) output += "(";
+        output += `"${node.image}"`;
+        if (i === nodes.length - 1) output += ")";
+        else output += ",";
+      }
+    });
+  });
+  return output;
+}

--- a/src/utils/printFilter.ts
+++ b/src/utils/printFilter.ts
@@ -1,0 +1,30 @@
+import { FilterTree } from "../FilterTree";
+
+/**
+ * Return the filter as a string.
+ *
+ * @param input filter tree
+ */
+export const printFilter = (input: FilterTree): string =>
+  input
+    .map(item => {
+      if (item.type === "operator") {
+        return (
+          ")".repeat(item.closeParentheses.length) +
+          (item.operator ? ` ${item.operator} ` : "") +
+          "(".repeat(item.openParentheses.length)
+        );
+      } else {
+        if (["in", "not in", "like"].includes(item.operator)) {
+          return `${item.dimension} ${item.operator} ${
+            item.value ? `(${item.value})` : ""
+          }`;
+        } else {
+          return `${item.dimension} ${item.operator} ${
+            item.value ? `${item.value}` : ""
+          }`;
+        }
+      }
+    })
+    .join("")
+    .trim();

--- a/src/utils/printFilter.ts
+++ b/src/utils/printFilter.ts
@@ -15,7 +15,7 @@ export const printFilter = (input: FilterTree): string =>
           "(".repeat(item.openParentheses.length)
         );
       } else {
-        if (["in", "not in", "like"].includes(item.operator)) {
+        if (["in", "not in"].includes(item.operator)) {
           return `${item.dimension} ${item.operator} ${
             item.value ? `(${item.value})` : ""
           }`;

--- a/src/visitors/FilterTreeVisitor.ts
+++ b/src/visitors/FilterTreeVisitor.ts
@@ -9,7 +9,7 @@ import { getImageFromChildren } from "../utils/getImageFromChildren";
 const Visitor = parser.getBaseCstVisitorConstructorWithDefaults();
 
 /**
- * Visitor to filter tree on the `WHERE` statement
+ * Visitor to extract filter tree on the `WHERE` statement
  */
 export class FilterTreeVisitor extends Visitor {
   public tree: FilterTree = [

--- a/src/visitors/FilterTreeVisitor.ts
+++ b/src/visitors/FilterTreeVisitor.ts
@@ -21,16 +21,16 @@ export class FilterTreeVisitor extends Visitor {
 
   private getOperator(expressionValue: BooleanExpressionValueContext) {
     if (expressionValue.BinaryOperator) {
-      return expressionValue.BinaryOperator[0].image as Operator;
+      return expressionValue.BinaryOperator[0].image.toLowerCase() as Operator;
     }
     if (expressionValue.MultivalOperator) {
-      return expressionValue.MultivalOperator[0].image as Operator;
+      return expressionValue.MultivalOperator[0].image.toLowerCase() as Operator;
     }
     if (expressionValue.IsNotNull) {
-      return expressionValue.IsNotNull[0].image as Operator;
+      return expressionValue.IsNotNull[0].image.toLowerCase() as Operator;
     }
     if (expressionValue.IsNull) {
-      return expressionValue.IsNull[0].image as Operator;
+      return expressionValue.IsNull[0].image.toLowerCase() as Operator;
     }
 
     return "="; // This is just to make typescript happy, this case is not possible with the actual grammar

--- a/src/visitors/FilterTreeVisitor.ts
+++ b/src/visitors/FilterTreeVisitor.ts
@@ -1,0 +1,102 @@
+import { parser } from "../SqlParser";
+import { FilterTree, Operator, isOperator } from "../FilterTree";
+import {
+  BooleanExpressionContext,
+  BooleanExpressionValueContext
+} from "../Context";
+import { getImageFromChildren } from "../utils/getImageFromChildren";
+
+const Visitor = parser.getBaseCstVisitorConstructorWithDefaults();
+
+/**
+ * Visitor to filter tree on the `WHERE` statement
+ */
+export class FilterTreeVisitor extends Visitor {
+  public tree: FilterTree = [
+    { type: "operator", closeParentheses: [], openParentheses: [] }
+  ];
+
+  private parenthesisCount = 0;
+  private parenthesisToClose: number[] = [];
+
+  private getOperator(expressionValue: BooleanExpressionValueContext) {
+    if (expressionValue.BinaryOperator) {
+      return expressionValue.BinaryOperator[0].image as Operator;
+    }
+    if (expressionValue.MultivalOperator) {
+      return expressionValue.MultivalOperator[0].image as Operator;
+    }
+    if (expressionValue.IsNotNull) {
+      return expressionValue.IsNotNull[0].image as Operator;
+    }
+    if (expressionValue.IsNull) {
+      return expressionValue.IsNull[0].image as Operator;
+    }
+
+    return "="; // This is just to make typescript happy, this case is not possible with the actual grammar
+  }
+
+  private getValue(expressionValue: BooleanExpressionValueContext) {
+    if (expressionValue.BinaryOperator) {
+      return getImageFromChildren(expressionValue.valueExpression[0].children);
+    }
+    if (expressionValue.MultivalOperator) {
+      return expressionValue.valueExpression
+        .map(i => getImageFromChildren(i.children))
+        .join(", ");
+    }
+
+    return undefined;
+  }
+
+  booleanExpression(ctx: BooleanExpressionContext) {
+    if (ctx.LParen && ctx.RParen) {
+      // Flag open parenthese
+      const startOperatorNode = this.tree[this.tree.length - 1];
+      if (isOperator(startOperatorNode)) {
+        this.parenthesisToClose.push(this.parenthesisCount);
+        startOperatorNode.openParentheses.unshift(this.parenthesisCount++);
+      }
+
+      // Visit inside
+      this.booleanExpression(ctx.booleanExpression[0].children);
+
+      // Flag close parenthese
+      const endOperatorNode = this.tree[this.tree.length - 1];
+      if (isOperator(endOperatorNode)) {
+        endOperatorNode.closeParentheses.push(
+          this.parenthesisToClose.shift() || 0
+        );
+      }
+    }
+
+    // Add predicate + operator on each value
+    if (ctx.booleanExpressionValue) {
+      ctx.booleanExpressionValue.forEach(predicate => {
+        this.tree.push({
+          type: "predicate",
+          dimension: predicate.children.Identifier[0].image,
+          operator: this.getOperator(predicate.children),
+          value: this.getValue(predicate.children)
+        });
+        this.tree.push({
+          type: "operator",
+          openParentheses: [],
+          closeParentheses: []
+        });
+      });
+    }
+
+    // Deal with `AND`/`OR`
+    if (ctx.Or || ctx.And) {
+      const lastOperatorNode = this.tree[this.tree.length - 1];
+      if (isOperator(lastOperatorNode)) {
+        lastOperatorNode.operator = ctx.Or ? "or" : "and";
+      }
+      // Visit alternative node
+      this.booleanExpression(
+        ctx.booleanExpression[ctx.booleanExpression.length - 1].children
+      );
+    }
+  }
+}

--- a/src/visitors/WhereVisitor.ts
+++ b/src/visitors/WhereVisitor.ts
@@ -1,0 +1,41 @@
+import { parser } from "../SqlParser";
+import { BooleanExpressionContext, TableExpressionContext } from "../Context";
+import { getChildrenRange } from "../utils/getChildrenRange";
+
+const Visitor = parser.getBaseCstVisitorConstructorWithDefaults();
+
+interface Location {
+  startLine: number;
+  endLine: number;
+  startColumn: number;
+  endColumn: number;
+}
+
+/**
+ * Visitor to extract information about `WHERE` statement
+ */
+export class WhereVisitor extends Visitor {
+  public location?: Location;
+  public booleanExpressionNode?: BooleanExpressionContext;
+
+  constructor() {
+    super();
+    this.validateVisitor();
+  }
+
+  tableExpression(ctx: TableExpressionContext) {
+    // Register end of tableExpression as location as fallback
+    const tableRange = getChildrenRange(ctx);
+    this.location = {
+      startLine: tableRange.endLine,
+      startColumn: tableRange.endColumn + 1,
+      endColumn: tableRange.endColumn + 1,
+      endLine: tableRange.endLine
+    };
+  }
+
+  booleanExpression(ctx: BooleanExpressionContext) {
+    this.location = getChildrenRange(ctx);
+    this.booleanExpressionNode = ctx;
+  }
+}


### PR DESCRIPTION
### Summary

We need to deal be able to update/add filters in an existing query. This PR add the grammar to support `WHERE` statement and some helpers.

I also add a `getFilterTree` to retrieve the filter part in as an array to be easily manipulated and display in a UI with the following component:

![image](https://user-images.githubusercontent.com/1761469/66996536-33d5ee00-f0d1-11e9-9441-36e4474d7602.png)
