### PR TITLE
Improve parser tests dx

### DIFF
--- a/src/SqlParser.parseSql.test.ts
+++ b/src/SqlParser.parseSql.test.ts
@@ -1,6 +1,6 @@
 import { parseSql } from "./SqlParser";
 import { ILexingError, IRecognitionException } from "chevrotain";
-import { prettifyCst } from "./utils/prettifyCst";
+import { prettifyCst, formatCst } from "./utils/prettifyCst";
 import fs from "fs";
 
 describe("parseSql", () => {
@@ -694,17 +694,23 @@ describe("parseSql", () => {
         const previous = fs.existsSync("debug.json")
           ? fs.readFileSync("debug.json", "utf-8")
           : "";
-        const next = JSON.stringify(result, null, 2);
+        const next =
+          "-----------------\n" +
+          "   Received\n" +
+          "-----------------\n" +
+          formatCst(prettifyCst(result.cst.children)) +
+          "\n\n-----------------\n" +
+          "   Expected\n" +
+          "-----------------\n" +
+          formatCst(expectedCst);
+
         if (previous !== next) {
           fs.writeFileSync("debug.json", next);
         }
       }
 
-      expect(prettifyCst(result.cst.children)).toEqual(
-        expectedCst
-          .split("\n")
-          .map(i => i.replace(/^\s*/g, "").replace(/, /g, ","))
-          .join("")
+      expect(formatCst(prettifyCst(result.cst.children))).toEqual(
+        formatCst(expectedCst)
       );
     });
   });

--- a/src/utils/prettifyCst.test.ts
+++ b/src/utils/prettifyCst.test.ts
@@ -1,0 +1,65 @@
+import { formatCst } from "./prettifyCst";
+
+describe("formatCst", () => {
+  it("should format an inline cst", () => {
+    const prettifiedCst =
+      'query(values(Values("VALUES")expression(IntegerValue("2"))expression(IntegerValue("3"))Comma(",")))';
+
+    expect(formatCst(prettifiedCst)).toMatchInlineSnapshot(`
+            "query(
+              values(
+                Values(\\"VALUES\\")
+                expression(
+                  IntegerValue(\\"2\\")
+                )
+                expression(
+                  IntegerValue(\\"3\\")
+                )
+                Comma(\\",\\")
+              )
+            )"
+        `);
+  });
+
+  it("should format a multine cst", () => {
+    const prettifiedCst = `query(
+      select(
+        Select("SELECT")
+        projectionItems(
+          projectionItem(Asterisk("*"))
+        )
+        From("FROM")
+        tableExpression(
+          tableReference(
+            tablePrimary(Identifier("my_db"))
+            As("AS")
+            Identifier("plop")
+          )
+        )
+      )
+    )`;
+
+    expect(formatCst(prettifiedCst)).toMatchInlineSnapshot(`
+      "query(
+        select(
+          Select(\\"SELECT\\")
+          projectionItems(
+            projectionItem(
+              Asterisk(\\"*\\")
+            )
+          )
+          From(\\"FROM\\")
+          tableExpression(
+            tableReference(
+              tablePrimary(
+                Identifier(\\"my_db\\")
+              )
+              As(\\"AS\\")
+              Identifier(\\"plop\\")
+            )
+          )
+        )
+      )"
+    `);
+  });
+});

--- a/src/utils/prettifyCst.ts
+++ b/src/utils/prettifyCst.ts
@@ -1,4 +1,10 @@
-import { CstChildrenDictionary } from "chevrotain";
+import {
+  CstChildrenDictionary,
+  createToken,
+  Lexer,
+  CstParser,
+  IToken
+} from "chevrotain";
 import { isCstNode } from "./isCstNode";
 
 /**
@@ -22,4 +28,101 @@ export function prettifyCst(cst: CstChildrenDictionary) {
     });
   });
   return output;
+}
+
+/**
+ * Indent the prettify version of the cst for more visibility
+ *
+ * @param cst output of `prettifyCst()`
+ */
+export function formatCst(prettifiedCst: string) {
+  const lexResult = PrettyCstLexer.tokenize(prettifiedCst);
+  parser.input = lexResult.tokens;
+
+  const cst = parser.node();
+  const visitor = new PrettyCstVisitor();
+  visitor.visit(cst);
+
+  return visitor.output
+    .split("\n")
+    .filter(i => i)
+    .join("\n");
+}
+
+// Lexer/Parser/Visitor to support `formatCst()`
+const Identifier = createToken({
+  name: "Identifier",
+  pattern: /[a-zA-Z]+/
+});
+const Value = createToken({
+  name: "Value",
+  pattern: /(("[^"\\]*(?:\\.[^"\\]*)*("))+)/
+});
+const LParen = createToken({ name: "LParen", pattern: /\(/ });
+const RParen = createToken({ name: "RParen", pattern: /\)/ });
+const WhiteSpace = createToken({
+  name: "WhiteSpace",
+  pattern: /\s+/,
+  group: Lexer.SKIPPED
+});
+const allTokens = [WhiteSpace, Identifier, Value, LParen, RParen];
+const PrettyCstLexer = new Lexer(allTokens, {
+  lineTerminatorCharacters: ["\n"]
+});
+
+class PrettyCstParser extends CstParser {
+  constructor() {
+    super(allTokens);
+    this.performSelfAnalysis();
+  }
+
+  public node = this.RULE("node", () => {
+    this.CONSUME(Identifier);
+    this.CONSUME(LParen);
+    this.OR([
+      { ALT: () => this.CONSUME(Value) },
+      { ALT: () => this.AT_LEAST_ONE(() => this.SUBRULE(this.node)) }
+    ]);
+    this.CONSUME(RParen);
+  });
+}
+
+const parser = new PrettyCstParser();
+
+const Visitor = parser.getBaseCstVisitorConstructorWithDefaults();
+
+interface NodeContext {
+  Identifier: IToken[];
+  LParen: IToken[];
+  Value?: IToken[];
+  node?: Array<{
+    name: "node";
+    children: NodeContext;
+  }>;
+  RParen: IToken[];
+}
+
+class PrettyCstVisitor extends Visitor {
+  public output = "";
+  private indent = "";
+
+  constructor() {
+    super();
+    this.validateVisitor();
+  }
+
+  node(ctx: NodeContext) {
+    this.output += this.indent + ctx.Identifier[0].image + ctx.LParen[0].image;
+
+    if (ctx.Value) {
+      this.output += ctx.Value[0].image + ctx.RParen[0].image + "\n";
+    } else if (ctx.node) {
+      this.output += "\n";
+      this.indent += "  ";
+      ctx.node.forEach(i => this.node(i.children));
+      this.output += "\n";
+      this.indent = this.indent.slice(0, -2);
+      this.output += this.indent + ctx.RParen[0].image + "\n";
+    }
+  }
 }


### PR DESCRIPTION
Developer experience (dx) is everything, this is why I made a last iteration on the parser test dx.

Before:
![image](https://user-images.githubusercontent.com/1761469/78351922-df9fc700-75a7-11ea-8be5-d0fe7c1686e6.png)

After:
![image](https://user-images.githubusercontent.com/1761469/78351800-b1ba8280-75a7-11ea-91f5-2f679b04668b.png)

To achieve this, I may create a lexer + parser + visitor just for this unit tests framework 🙄 So now we have a parser to test another parser #inception 

Other benefit, the `debug: true` is now very neat, since we don't need to indent the output ourself:

![image](https://user-images.githubusercontent.com/1761469/78352222-48873f00-75a8-11ea-8b55-5b4da821b31a.png)

(This is just because sometime it's easier to manipulate files instead of console output)