### PR TITLE
Add JOIN support

### DIFF
--- a/docs/diagrams.html
+++ b/docs/diagrams.html
@@ -600,7 +600,7 @@
       type: "Rule",
       name: "booleanExpressionValue",
       orgText:
-        "function () {\r\n            _this.SUBRULE(_this.columnPrimary);\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        // Binary operation\r\n                        _this.CONSUME(BinaryOperator);\r\n                        _this.SUBRULE(_this.valueExpression);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Multival operation\r\n                        _this.CONSUME(MultivalOperator);\r\n                        _this.CONSUME1(LParen);\r\n                        _this.AT_LEAST_ONE_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE1(_this.valueExpression); }\r\n                        });\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Unary operation\r\n                        _this.OR2([\r\n                            { ALT: function () { return _this.CONSUME(IsNull); } },\r\n                            { ALT: function () { return _this.CONSUME(IsNotNull); } }\r\n                        ]);\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+        "function () {\r\n            _this.SUBRULE(_this.columnPrimary);\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        // Binary operation\r\n                        _this.CONSUME(BinaryOperator);\r\n                        _this.OR1([\r\n                            { ALT: function () { return _this.SUBRULE1(_this.valueExpression); } },\r\n                            { ALT: function () { return _this.SUBRULE2(_this.columnPrimary); } }\r\n                        ]);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Multival operation\r\n                        _this.CONSUME(MultivalOperator);\r\n                        _this.CONSUME1(LParen);\r\n                        _this.AT_LEAST_ONE_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () {\r\n                                _this.OR2([\r\n                                    { ALT: function () { return _this.SUBRULE3(_this.valueExpression); } },\r\n                                    { ALT: function () { return _this.SUBRULE4(_this.columnPrimary); } }\r\n                                ]);\r\n                            }\r\n                        });\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Unary operation\r\n                        _this.OR3([\r\n                            { ALT: function () { return _this.CONSUME(IsNull); } },\r\n                            { ALT: function () { return _this.CONSUME(IsNotNull); } }\r\n                        ]);\r\n                    }\r\n                }\r\n            ]);\r\n        }",
       definition: [
         {
           type: "NonTerminal",
@@ -622,9 +622,30 @@
                   pattern: "=|>=?|<=?|\\!=|LIKE"
                 },
                 {
-                  type: "NonTerminal",
-                  name: "valueExpression",
-                  idx: 0
+                  type: "Alternation",
+                  idx: 1,
+                  definition: [
+                    {
+                      type: "Flat",
+                      definition: [
+                        {
+                          type: "NonTerminal",
+                          name: "valueExpression",
+                          idx: 1
+                        }
+                      ]
+                    },
+                    {
+                      type: "Flat",
+                      definition: [
+                        {
+                          type: "NonTerminal",
+                          name: "columnPrimary",
+                          idx: 2
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             },
@@ -657,9 +678,30 @@
                   },
                   definition: [
                     {
-                      type: "NonTerminal",
-                      name: "valueExpression",
-                      idx: 1
+                      type: "Alternation",
+                      idx: 2,
+                      definition: [
+                        {
+                          type: "Flat",
+                          definition: [
+                            {
+                              type: "NonTerminal",
+                              name: "valueExpression",
+                              idx: 3
+                            }
+                          ]
+                        },
+                        {
+                          type: "Flat",
+                          definition: [
+                            {
+                              type: "NonTerminal",
+                              name: "columnPrimary",
+                              idx: 4
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 },
@@ -677,7 +719,7 @@
               definition: [
                 {
                   type: "Alternation",
-                  idx: 2,
+                  idx: 3,
                   definition: [
                     {
                       type: "Flat",
@@ -1014,30 +1056,204 @@
       type: "Rule",
       name: "tableExpression",
       orgText:
-        "function () {\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        _this.MANY_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE(_this.tableReference); }\r\n                        });\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+        "function () {\r\n            // tableReference [, tableReference ]*\r\n            _this.MANY_SEP({\r\n                SEP: Comma,\r\n                DEF: function () { return _this.SUBRULE(_this.tableReference); }\r\n            });\r\n            _this.OPTION(function () {\r\n                _this.OR([\r\n                    {\r\n                        // [ NATURAL ] [ ( LEFT | RIGHT | FULL ) [ OUTER ] ] JOIN tableExpression [ joinCondition ]\r\n                        ALT: function () {\r\n                            _this.OPTION1(function () { return _this.CONSUME(Natural); });\r\n                            _this.OPTION2(function () {\r\n                                _this.OR1([\r\n                                    { ALT: function () { return _this.CONSUME(Left); } },\r\n                                    { ALT: function () { return _this.CONSUME(Right); } },\r\n                                    { ALT: function () { return _this.CONSUME(Full); } }\r\n                                ]);\r\n                                _this.OPTION3(function () { return _this.CONSUME(Outer); });\r\n                            });\r\n                            _this.CONSUME(Join);\r\n                            _this.SUBRULE1(_this.tableExpression);\r\n                            _this.OPTION4(function () { return _this.SUBRULE2(_this.joinCondition); });\r\n                        }\r\n                    },\r\n                    {\r\n                        // CROSS JOIN tableExpression\r\n                        ALT: function () {\r\n                            _this.CONSUME(Cross);\r\n                            _this.CONSUME2(Join);\r\n                            _this.SUBRULE2(_this.tableExpression);\r\n                        }\r\n                    },\r\n                    {\r\n                        // [ CROSS | OUTER ] APPLY tableExpression\r\n                        ALT: function () {\r\n                            _this.OR2([\r\n                                { ALT: function () { return _this.CONSUME1(Cross); } },\r\n                                { ALT: function () { return _this.CONSUME1(Outer); } }\r\n                            ]);\r\n                            _this.CONSUME(Apply);\r\n                            _this.SUBRULE3(_this.tableExpression);\r\n                        }\r\n                    }\r\n                ]);\r\n            });\r\n        }",
       definition: [
         {
-          type: "Alternation",
+          type: "RepetitionWithSeparator",
+          idx: 0,
+          separator: {
+            type: "Terminal",
+            name: "Comma",
+            label: "Comma",
+            idx: 1,
+            pattern: ","
+          },
+          definition: [
+            {
+              type: "NonTerminal",
+              name: "tableReference",
+              idx: 0
+            }
+          ]
+        },
+        {
+          type: "Option",
           idx: 0,
           definition: [
             {
-              type: "Flat",
+              type: "Alternation",
+              idx: 0,
               definition: [
                 {
-                  type: "RepetitionWithSeparator",
-                  idx: 0,
-                  separator: {
-                    type: "Terminal",
-                    name: "Comma",
-                    label: "Comma",
-                    idx: 1,
-                    pattern: ","
-                  },
+                  type: "Flat",
                   definition: [
                     {
+                      type: "Option",
+                      idx: 1,
+                      definition: [
+                        {
+                          type: "Terminal",
+                          name: "Natural",
+                          label: "Natural",
+                          idx: 0,
+                          pattern: "NATURAL"
+                        }
+                      ]
+                    },
+                    {
+                      type: "Option",
+                      idx: 2,
+                      definition: [
+                        {
+                          type: "Alternation",
+                          idx: 1,
+                          definition: [
+                            {
+                              type: "Flat",
+                              definition: [
+                                {
+                                  type: "Terminal",
+                                  name: "Left",
+                                  label: "Left",
+                                  idx: 0,
+                                  pattern: "LEFT"
+                                }
+                              ]
+                            },
+                            {
+                              type: "Flat",
+                              definition: [
+                                {
+                                  type: "Terminal",
+                                  name: "Right",
+                                  label: "Right",
+                                  idx: 0,
+                                  pattern: "RIGHT"
+                                }
+                              ]
+                            },
+                            {
+                              type: "Flat",
+                              definition: [
+                                {
+                                  type: "Terminal",
+                                  name: "Full",
+                                  label: "Full",
+                                  idx: 0,
+                                  pattern: "FULL"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          type: "Option",
+                          idx: 3,
+                          definition: [
+                            {
+                              type: "Terminal",
+                              name: "Outer",
+                              label: "Outer",
+                              idx: 0,
+                              pattern: "OUTER"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      type: "Terminal",
+                      name: "Join",
+                      label: "Join",
+                      idx: 0,
+                      pattern: "JOIN"
+                    },
+                    {
                       type: "NonTerminal",
-                      name: "tableReference",
-                      idx: 0
+                      name: "tableExpression",
+                      idx: 1
+                    },
+                    {
+                      type: "Option",
+                      idx: 4,
+                      definition: [
+                        {
+                          type: "NonTerminal",
+                          name: "joinCondition",
+                          idx: 2
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  type: "Flat",
+                  definition: [
+                    {
+                      type: "Terminal",
+                      name: "Cross",
+                      label: "Cross",
+                      idx: 0,
+                      pattern: "CROSS"
+                    },
+                    {
+                      type: "Terminal",
+                      name: "Join",
+                      label: "Join",
+                      idx: 2,
+                      pattern: "JOIN"
+                    },
+                    {
+                      type: "NonTerminal",
+                      name: "tableExpression",
+                      idx: 2
+                    }
+                  ]
+                },
+                {
+                  type: "Flat",
+                  definition: [
+                    {
+                      type: "Alternation",
+                      idx: 2,
+                      definition: [
+                        {
+                          type: "Flat",
+                          definition: [
+                            {
+                              type: "Terminal",
+                              name: "Cross",
+                              label: "Cross",
+                              idx: 1,
+                              pattern: "CROSS"
+                            }
+                          ]
+                        },
+                        {
+                          type: "Flat",
+                          definition: [
+                            {
+                              type: "Terminal",
+                              name: "Outer",
+                              label: "Outer",
+                              idx: 1,
+                              pattern: "OUTER"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      type: "Terminal",
+                      name: "Apply",
+                      label: "Apply",
+                      idx: 0,
+                      pattern: "APPLY"
+                    },
+                    {
+                      type: "NonTerminal",
+                      name: "tableExpression",
+                      idx: 3
                     }
                   ]
                 }
@@ -1050,8 +1266,64 @@
     {
       type: "Rule",
       name: "joinCondition",
-      orgText: "function () { }",
-      definition: []
+      orgText:
+        "function () {\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(On);\r\n                        _this.SUBRULE(_this.booleanExpression);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(Using);\r\n                        _this.CONSUME(LParen);\r\n                        _this.SUBRULE(_this.projectionItems);\r\n                        _this.CONSUME(RParen);\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+      definition: [
+        {
+          type: "Alternation",
+          idx: 0,
+          definition: [
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "On",
+                  label: "On",
+                  idx: 0,
+                  pattern: "ON"
+                },
+                {
+                  type: "NonTerminal",
+                  name: "booleanExpression",
+                  idx: 0
+                }
+              ]
+            },
+            {
+              type: "Flat",
+              definition: [
+                {
+                  type: "Terminal",
+                  name: "Using",
+                  label: "Using",
+                  idx: 0,
+                  pattern: "USING"
+                },
+                {
+                  type: "Terminal",
+                  name: "LParen",
+                  label: "LParen",
+                  idx: 0,
+                  pattern: "\\("
+                },
+                {
+                  type: "NonTerminal",
+                  name: "projectionItems",
+                  idx: 0
+                },
+                {
+                  type: "Terminal",
+                  name: "RParen",
+                  label: "RParen",
+                  idx: 0,
+                  pattern: "\\)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
       type: "Rule",

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -132,11 +132,23 @@ export type BooleanExpressionValueContext =
       }>;
     }
   | {
+      columnPrimary: Array<{
+        name: "columnPrimary";
+        children: ColumnPrimaryContext;
+      }>;
+    }
+  | {
       MultivalOperator: IToken[];
       LParen: IToken[];
       valueExpression: Array<{
         name: "valueExpression";
         children: ValueExpressionContext;
+      }>;
+    }
+  | {
+      columnPrimary: Array<{
+        name: "columnPrimary";
+        children: ColumnPrimaryContext;
       }>;
       Comma?: IToken[];
       RParen: IToken[];
@@ -202,9 +214,58 @@ export type ProjectionItemContext =
     }
   | { Asterisk: IToken[] };
 
-export interface TableExpressionContext {}
+export type TableExpressionContext =
+  | {
+      Natural?: IToken[];
+      Left?: IToken[];
+      Right?: IToken[];
+      Full?: IToken[];
+      Outer?: IToken[];
+      Join: IToken[];
+      tableExpression: Array<{
+        name: "tableExpression";
+        children: TableExpressionContext;
+      }>;
+      joinCondition?: Array<{
+        name: "joinCondition";
+        children: JoinConditionContext;
+      }>;
+    }
+  | {
+      Cross: IToken[];
+      Join: IToken[];
+      tableExpression: Array<{
+        name: "tableExpression";
+        children: TableExpressionContext;
+      }>;
+    }
+  | {
+      Cross?: IToken[];
+      Outer?: IToken[];
+      Apply: IToken[];
+      tableExpression: Array<{
+        name: "tableExpression";
+        children: TableExpressionContext;
+      }>;
+    };
 
-export interface JoinConditionContext {}
+export type JoinConditionContext =
+  | {
+      On: IToken[];
+      booleanExpression: Array<{
+        name: "booleanExpression";
+        children: BooleanExpressionContext;
+      }>;
+    }
+  | {
+      Using: IToken[];
+      LParen: IToken[];
+      projectionItems: Array<{
+        name: "projectionItems";
+        children: ProjectionItemsContext;
+      }>;
+      RParen: IToken[];
+    };
 
 export interface TableReferenceContext {
   tablePrimary: Array<{

--- a/src/SqlParser.lexer.test.ts
+++ b/src/SqlParser.lexer.test.ts
@@ -270,6 +270,18 @@ describe("Sql Lexer", () => {
       title: "date",
       sql: "date '2019-02-01'",
       expected: ["date '2019-02-01' => DateValue"]
+    },
+    {
+      title: "join keywords",
+      sql: "NATURAL LEFT RIGHT FULL OUTER JOIN",
+      expected: [
+        "NATURAL => Natural",
+        "LEFT => Left",
+        "RIGHT => Right",
+        "FULL => Full",
+        "OUTER => Outer",
+        "JOIN => Join"
+      ]
     }
   ];
 

--- a/src/SqlParser.lexer.test.ts
+++ b/src/SqlParser.lexer.test.ts
@@ -273,14 +273,16 @@ describe("Sql Lexer", () => {
     },
     {
       title: "join keywords",
-      sql: "NATURAL LEFT RIGHT FULL OUTER JOIN",
+      sql: "NATURAL LEFT RIGHT FULL OUTER JOIN CROSS APPLY",
       expected: [
         "NATURAL => Natural",
         "LEFT => Left",
         "RIGHT => Right",
         "FULL => Full",
         "OUTER => Outer",
-        "JOIN => Join"
+        "JOIN => Join",
+        "CROSS => Cross",
+        "APPLY => Apply"
       ]
     }
   ];

--- a/src/SqlParser.parseSql.test.ts
+++ b/src/SqlParser.parseSql.test.ts
@@ -655,21 +655,52 @@ describe("parseSql", () => {
       title: "table alias",
       sql: "SELECT * FROM my_db AS plop",
       expected: `query(
-      select(
-        Select("SELECT")
-        projectionItems(
-          projectionItem(Asterisk("*"))
-        )
-        From("FROM")
-        tableExpression(
-          tableReference(
-            tablePrimary(Identifier("my_db"))
-            As("AS")
-            Identifier("plop")
+        select(
+          Select("SELECT")
+          projectionItems(
+            projectionItem(Asterisk("*"))
+          )
+          From("FROM")
+          tableExpression(
+            tableReference(
+              tablePrimary(Identifier("my_db"))
+              As("AS")
+              Identifier("plop")
+            )
           )
         )
-      )
-    )`
+      )`
+    },
+    {
+      title: "natural join",
+      sql: "SELECT * FROM my_db NATURAL JOIN my_other_db",
+      expected: `query(
+        select(
+          Select("SELECT")
+          projectionItems(
+            projectionItem(
+              Asterisk("*")
+            )
+          )
+          From("FROM")
+          tableExpression(
+            tableReference(
+              tablePrimary(
+                Identifier("my_db")
+              )
+            )
+            Natural("NATURAL")
+            Join("JOIN")
+            tableExpression(
+              tableReference(
+                tablePrimary(
+                  Identifier("my_other_db")
+                )
+              )
+            )
+          )
+        )
+      )`
     }
   ];
 

--- a/src/SqlParser.parseSql.test.ts
+++ b/src/SqlParser.parseSql.test.ts
@@ -782,6 +782,37 @@ describe("parseSql", () => {
           )
         )
       )`
+    },
+    {
+      title: "cross apply",
+      sql: "SELECT * FROM table_a CROSS APPLY table_b",
+      expected: `query(
+        select(
+          Select("SELECT")
+          projectionItems(
+            projectionItem(
+              Asterisk("*")
+            )
+          )
+          From("FROM")
+          tableExpression(
+            tableReference(
+              tablePrimary(
+                Identifier("table_a")
+              )
+            )
+            Cross("CROSS")
+            Apply("APPLY")
+            tableExpression(
+              tableReference(
+                tablePrimary(
+                  Identifier("table_b")
+                )
+              )
+            )
+          )
+        )
+      )`
     }
   ];
 

--- a/src/SqlParser.parseSql.test.ts
+++ b/src/SqlParser.parseSql.test.ts
@@ -697,8 +697,6 @@ describe("parseSql", () => {
     },
     {
       title: "join on",
-      debug: true,
-      only: true,
       sql: `SELECT
               *
             FROM
@@ -747,6 +745,37 @@ describe("parseSql", () => {
                     Period(".")
                   )
                   BinaryOperator("=")
+                )
+              )
+            )
+          )
+        )
+      )`
+    },
+    {
+      title: "cross join",
+      sql: "SELECT * FROM table_a CROSS JOIN table_b",
+      expected: `query(
+        select(
+          Select("SELECT")
+          projectionItems(
+            projectionItem(
+              Asterisk("*")
+            )
+          )
+          From("FROM")
+          tableExpression(
+            tableReference(
+              tablePrimary(
+                Identifier("table_a")
+              )
+            )
+            Cross("CROSS")
+            Join("JOIN")
+            tableExpression(
+              tableReference(
+                tablePrimary(
+                  Identifier("table_b")
                 )
               )
             )

--- a/src/SqlParser.ts
+++ b/src/SqlParser.ts
@@ -86,6 +86,42 @@ const Where = createToken({
   longer_alt: Identifier
 });
 
+const Natural = createToken({
+  name: "Natural",
+  pattern: /NATURAL/i,
+  longer_alt: Identifier
+});
+
+const Left = createToken({
+  name: "Left",
+  pattern: /LEFT/i,
+  longer_alt: Identifier
+});
+
+const Right = createToken({
+  name: "Right",
+  pattern: /RIGHT/i,
+  longer_alt: Identifier
+});
+
+const Full = createToken({
+  name: "Full",
+  pattern: /FULL/i,
+  longer_alt: Identifier
+});
+
+const Outer = createToken({
+  name: "Outer",
+  pattern: /OUTER/i,
+  longer_alt: Identifier
+});
+
+const Join = createToken({
+  name: "Join",
+  pattern: /JOIN/i,
+  longer_alt: Identifier
+});
+
 const Values = createToken({
   name: "Values",
   pattern: /VALUES/i,
@@ -202,6 +238,12 @@ const allTokens = [
   Select,
   From,
   Where,
+  Natural,
+  Left,
+  Right,
+  Full,
+  Outer,
+  Join,
   Values,
   And,
   OrderBy,

--- a/src/SqlParser.ts
+++ b/src/SqlParser.ts
@@ -619,16 +619,33 @@ class SqlParser extends CstParser {
    *  |   tableExpression [ CROSS | OUTER ] APPLY tableExpression
    */
   public tableExpression = this.RULE("tableExpression", () => {
-    this.OR([
-      {
-        ALT: () => {
-          this.MANY_SEP({
-            SEP: Comma,
-            DEF: () => this.SUBRULE(this.tableReference)
-          });
+    // tableReference [, tableReference ]*
+    this.MANY_SEP({
+      SEP: Comma,
+      DEF: () => this.SUBRULE(this.tableReference)
+    });
+
+    this.OPTION(() => {
+      this.OR([
+        {
+          // [ NATURAL ] [ ( LEFT | RIGHT | FULL ) [ OUTER ] ] JOIN tableExpression [ joinCondition ]
+          ALT: () => {
+            this.OPTION1(() => this.CONSUME(Natural));
+            this.OPTION2(() => {
+              this.OR1([
+                { ALT: () => this.CONSUME(Left) },
+                { ALT: () => this.CONSUME(Right) },
+                { ALT: () => this.CONSUME(Full) }
+              ]);
+              this.OPTION3(() => this.CONSUME(Outer));
+            });
+            this.CONSUME(Join);
+            this.SUBRULE1(this.tableExpression);
+            // join condition (optionnal)
+          }
         }
-      }
-    ]);
+      ]);
+    });
   });
 
   /**

--- a/src/SqlParser.ts
+++ b/src/SqlParser.ts
@@ -687,6 +687,17 @@ class SqlParser extends CstParser {
             this.CONSUME2(Join);
             this.SUBRULE2(this.tableExpression);
           }
+        },
+        {
+          // [ CROSS | OUTER ] APPLY tableExpression
+          ALT: () => {
+            this.OR2([
+              { ALT: () => this.CONSUME1(Cross) },
+              { ALT: () => this.CONSUME1(Outer) }
+            ]);
+            this.CONSUME(Apply);
+            this.SUBRULE3(this.tableExpression);
+          }
         }
       ]);
     });

--- a/src/SqlParser.ts
+++ b/src/SqlParser.ts
@@ -116,6 +116,18 @@ const Outer = createToken({
   longer_alt: Identifier
 });
 
+const Cross = createToken({
+  name: "Cross",
+  pattern: /CROSS/i,
+  longer_alt: Identifier
+});
+
+const Apply = createToken({
+  name: "Apply",
+  pattern: /APPLY/i,
+  longer_alt: Identifier
+});
+
 const Join = createToken({
   name: "Join",
   pattern: /JOIN/i,
@@ -255,6 +267,8 @@ const allTokens = [
   Right,
   Full,
   Outer,
+  Cross,
+  Apply,
   Join,
   On,
   Using,
@@ -664,6 +678,14 @@ class SqlParser extends CstParser {
             this.CONSUME(Join);
             this.SUBRULE1(this.tableExpression);
             this.OPTION4(() => this.SUBRULE2(this.joinCondition));
+          }
+        },
+        {
+          // CROSS JOIN tableExpression
+          ALT: () => {
+            this.CONSUME(Cross);
+            this.CONSUME2(Join);
+            this.SUBRULE2(this.tableExpression);
           }
         }
       ]);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -454,7 +454,8 @@ describe("rhombic", () => {
       "my_column = 'Berlin'",
       "my_column in ('Paris', 'Berlin')",
       "my_column is null",
-      "my_column is not null"
+      "my_column is not null",
+      "my_column = Berlin"
     ].forEach(i =>
       it(`should return true for "${i}"`, () => {
         const isValid = rhombic.isFilterValid(i);
@@ -463,11 +464,7 @@ describe("rhombic", () => {
     );
 
     // Not valid cases
-    [
-      "my_column = 'Berlin",
-      "my_column = 'Paris', 'Berlin'",
-      "my_column = Berlin"
-    ].forEach(i =>
+    ["my_column = 'Berlin", "my_column = 'Paris', 'Berlin'"].forEach(i =>
       it(`should return false for "${i}"`, () => {
         const isValid = rhombic.isFilterValid(i);
         expect(isValid).toBeFalsy();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -139,6 +139,36 @@ describe("rhombic", () => {
         }
       ]);
     });
+
+    it("should return two tables with a join", () => {
+      const tables = rhombic
+        .parse(
+          "SELECT * FROM myschema.mytable AS a LEFT JOIN mytable2 AS b on (a.id = b.id)"
+        )
+        .getTablePrimaries();
+
+      expect(tables).toEqual([
+        {
+          location: {
+            endColumn: 30,
+            endLine: 1,
+            startColumn: 15,
+            startLine: 1
+          },
+          schemaName: "myschema",
+          tableName: "mytable"
+        },
+        {
+          location: {
+            endColumn: 54,
+            endLine: 1,
+            startColumn: 47,
+            startLine: 1
+          },
+          tableName: "mytable2"
+        }
+      ]);
+    });
   });
 
   describe("orderBy", () => {
@@ -297,6 +327,17 @@ describe("rhombic", () => {
           CUSTOM_MEMBERS
         FROM
           "foodmart"."ACCOUNT" ORDER BY felix`);
+    });
+
+    it("should add an ORDER_BY on statement with join", () => {
+      const query = rhombic
+        .parse("SELECT * FROM myschema.mytable NATURAL JOIN mytable2")
+        .orderBy({ expression: "ACCOUNT_ID" })
+        .toString();
+
+      expect(query).toEqual(
+        "SELECT * FROM myschema.mytable NATURAL JOIN mytable2 ORDER BY ACCOUNT_ID"
+      );
     });
   });
 

--- a/src/serializedGrammar.ts
+++ b/src/serializedGrammar.ts
@@ -580,7 +580,7 @@ export const serializedGrammar = [
     type: "Rule",
     name: "booleanExpressionValue",
     orgText:
-      "function () {\r\n            _this.SUBRULE(_this.columnPrimary);\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        // Binary operation\r\n                        _this.CONSUME(BinaryOperator);\r\n                        _this.SUBRULE(_this.valueExpression);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Multival operation\r\n                        _this.CONSUME(MultivalOperator);\r\n                        _this.CONSUME1(LParen);\r\n                        _this.AT_LEAST_ONE_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE1(_this.valueExpression); }\r\n                        });\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Unary operation\r\n                        _this.OR2([\r\n                            { ALT: function () { return _this.CONSUME(IsNull); } },\r\n                            { ALT: function () { return _this.CONSUME(IsNotNull); } }\r\n                        ]);\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+      "function () {\r\n            _this.SUBRULE(_this.columnPrimary);\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        // Binary operation\r\n                        _this.CONSUME(BinaryOperator);\r\n                        _this.OR1([\r\n                            { ALT: function () { return _this.SUBRULE1(_this.valueExpression); } },\r\n                            { ALT: function () { return _this.SUBRULE2(_this.columnPrimary); } }\r\n                        ]);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Multival operation\r\n                        _this.CONSUME(MultivalOperator);\r\n                        _this.CONSUME1(LParen);\r\n                        _this.AT_LEAST_ONE_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () {\r\n                                _this.OR2([\r\n                                    { ALT: function () { return _this.SUBRULE3(_this.valueExpression); } },\r\n                                    { ALT: function () { return _this.SUBRULE4(_this.columnPrimary); } }\r\n                                ]);\r\n                            }\r\n                        });\r\n                        _this.CONSUME1(RParen);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        // Unary operation\r\n                        _this.OR3([\r\n                            { ALT: function () { return _this.CONSUME(IsNull); } },\r\n                            { ALT: function () { return _this.CONSUME(IsNotNull); } }\r\n                        ]);\r\n                    }\r\n                }\r\n            ]);\r\n        }",
     definition: [
       {
         type: "NonTerminal",
@@ -602,9 +602,30 @@ export const serializedGrammar = [
                 pattern: "=|>=?|<=?|\\!=|LIKE"
               },
               {
-                type: "NonTerminal",
-                name: "valueExpression",
-                idx: 0
+                type: "Alternation",
+                idx: 1,
+                definition: [
+                  {
+                    type: "Flat",
+                    definition: [
+                      {
+                        type: "NonTerminal",
+                        name: "valueExpression",
+                        idx: 1
+                      }
+                    ]
+                  },
+                  {
+                    type: "Flat",
+                    definition: [
+                      {
+                        type: "NonTerminal",
+                        name: "columnPrimary",
+                        idx: 2
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -637,9 +658,30 @@ export const serializedGrammar = [
                 },
                 definition: [
                   {
-                    type: "NonTerminal",
-                    name: "valueExpression",
-                    idx: 1
+                    type: "Alternation",
+                    idx: 2,
+                    definition: [
+                      {
+                        type: "Flat",
+                        definition: [
+                          {
+                            type: "NonTerminal",
+                            name: "valueExpression",
+                            idx: 3
+                          }
+                        ]
+                      },
+                      {
+                        type: "Flat",
+                        definition: [
+                          {
+                            type: "NonTerminal",
+                            name: "columnPrimary",
+                            idx: 4
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               },
@@ -657,7 +699,7 @@ export const serializedGrammar = [
             definition: [
               {
                 type: "Alternation",
-                idx: 2,
+                idx: 3,
                 definition: [
                   {
                     type: "Flat",
@@ -994,30 +1036,204 @@ export const serializedGrammar = [
     type: "Rule",
     name: "tableExpression",
     orgText:
-      "function () {\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        _this.MANY_SEP({\r\n                            SEP: Comma,\r\n                            DEF: function () { return _this.SUBRULE(_this.tableReference); }\r\n                        });\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+      "function () {\r\n            // tableReference [, tableReference ]*\r\n            _this.MANY_SEP({\r\n                SEP: Comma,\r\n                DEF: function () { return _this.SUBRULE(_this.tableReference); }\r\n            });\r\n            _this.OPTION(function () {\r\n                _this.OR([\r\n                    {\r\n                        // [ NATURAL ] [ ( LEFT | RIGHT | FULL ) [ OUTER ] ] JOIN tableExpression [ joinCondition ]\r\n                        ALT: function () {\r\n                            _this.OPTION1(function () { return _this.CONSUME(Natural); });\r\n                            _this.OPTION2(function () {\r\n                                _this.OR1([\r\n                                    { ALT: function () { return _this.CONSUME(Left); } },\r\n                                    { ALT: function () { return _this.CONSUME(Right); } },\r\n                                    { ALT: function () { return _this.CONSUME(Full); } }\r\n                                ]);\r\n                                _this.OPTION3(function () { return _this.CONSUME(Outer); });\r\n                            });\r\n                            _this.CONSUME(Join);\r\n                            _this.SUBRULE1(_this.tableExpression);\r\n                            _this.OPTION4(function () { return _this.SUBRULE2(_this.joinCondition); });\r\n                        }\r\n                    },\r\n                    {\r\n                        // CROSS JOIN tableExpression\r\n                        ALT: function () {\r\n                            _this.CONSUME(Cross);\r\n                            _this.CONSUME2(Join);\r\n                            _this.SUBRULE2(_this.tableExpression);\r\n                        }\r\n                    },\r\n                    {\r\n                        // [ CROSS | OUTER ] APPLY tableExpression\r\n                        ALT: function () {\r\n                            _this.OR2([\r\n                                { ALT: function () { return _this.CONSUME1(Cross); } },\r\n                                { ALT: function () { return _this.CONSUME1(Outer); } }\r\n                            ]);\r\n                            _this.CONSUME(Apply);\r\n                            _this.SUBRULE3(_this.tableExpression);\r\n                        }\r\n                    }\r\n                ]);\r\n            });\r\n        }",
     definition: [
       {
-        type: "Alternation",
+        type: "RepetitionWithSeparator",
+        idx: 0,
+        separator: {
+          type: "Terminal",
+          name: "Comma",
+          label: "Comma",
+          idx: 1,
+          pattern: ","
+        },
+        definition: [
+          {
+            type: "NonTerminal",
+            name: "tableReference",
+            idx: 0
+          }
+        ]
+      },
+      {
+        type: "Option",
         idx: 0,
         definition: [
           {
-            type: "Flat",
+            type: "Alternation",
+            idx: 0,
             definition: [
               {
-                type: "RepetitionWithSeparator",
-                idx: 0,
-                separator: {
-                  type: "Terminal",
-                  name: "Comma",
-                  label: "Comma",
-                  idx: 1,
-                  pattern: ","
-                },
+                type: "Flat",
                 definition: [
                   {
+                    type: "Option",
+                    idx: 1,
+                    definition: [
+                      {
+                        type: "Terminal",
+                        name: "Natural",
+                        label: "Natural",
+                        idx: 0,
+                        pattern: "NATURAL"
+                      }
+                    ]
+                  },
+                  {
+                    type: "Option",
+                    idx: 2,
+                    definition: [
+                      {
+                        type: "Alternation",
+                        idx: 1,
+                        definition: [
+                          {
+                            type: "Flat",
+                            definition: [
+                              {
+                                type: "Terminal",
+                                name: "Left",
+                                label: "Left",
+                                idx: 0,
+                                pattern: "LEFT"
+                              }
+                            ]
+                          },
+                          {
+                            type: "Flat",
+                            definition: [
+                              {
+                                type: "Terminal",
+                                name: "Right",
+                                label: "Right",
+                                idx: 0,
+                                pattern: "RIGHT"
+                              }
+                            ]
+                          },
+                          {
+                            type: "Flat",
+                            definition: [
+                              {
+                                type: "Terminal",
+                                name: "Full",
+                                label: "Full",
+                                idx: 0,
+                                pattern: "FULL"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        type: "Option",
+                        idx: 3,
+                        definition: [
+                          {
+                            type: "Terminal",
+                            name: "Outer",
+                            label: "Outer",
+                            idx: 0,
+                            pattern: "OUTER"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    type: "Terminal",
+                    name: "Join",
+                    label: "Join",
+                    idx: 0,
+                    pattern: "JOIN"
+                  },
+                  {
                     type: "NonTerminal",
-                    name: "tableReference",
-                    idx: 0
+                    name: "tableExpression",
+                    idx: 1
+                  },
+                  {
+                    type: "Option",
+                    idx: 4,
+                    definition: [
+                      {
+                        type: "NonTerminal",
+                        name: "joinCondition",
+                        idx: 2
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                type: "Flat",
+                definition: [
+                  {
+                    type: "Terminal",
+                    name: "Cross",
+                    label: "Cross",
+                    idx: 0,
+                    pattern: "CROSS"
+                  },
+                  {
+                    type: "Terminal",
+                    name: "Join",
+                    label: "Join",
+                    idx: 2,
+                    pattern: "JOIN"
+                  },
+                  {
+                    type: "NonTerminal",
+                    name: "tableExpression",
+                    idx: 2
+                  }
+                ]
+              },
+              {
+                type: "Flat",
+                definition: [
+                  {
+                    type: "Alternation",
+                    idx: 2,
+                    definition: [
+                      {
+                        type: "Flat",
+                        definition: [
+                          {
+                            type: "Terminal",
+                            name: "Cross",
+                            label: "Cross",
+                            idx: 1,
+                            pattern: "CROSS"
+                          }
+                        ]
+                      },
+                      {
+                        type: "Flat",
+                        definition: [
+                          {
+                            type: "Terminal",
+                            name: "Outer",
+                            label: "Outer",
+                            idx: 1,
+                            pattern: "OUTER"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    type: "Terminal",
+                    name: "Apply",
+                    label: "Apply",
+                    idx: 0,
+                    pattern: "APPLY"
+                  },
+                  {
+                    type: "NonTerminal",
+                    name: "tableExpression",
+                    idx: 3
                   }
                 ]
               }
@@ -1030,8 +1246,64 @@ export const serializedGrammar = [
   {
     type: "Rule",
     name: "joinCondition",
-    orgText: "function () { }",
-    definition: []
+    orgText:
+      "function () {\r\n            _this.OR([\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(On);\r\n                        _this.SUBRULE(_this.booleanExpression);\r\n                    }\r\n                },\r\n                {\r\n                    ALT: function () {\r\n                        _this.CONSUME(Using);\r\n                        _this.CONSUME(LParen);\r\n                        _this.SUBRULE(_this.projectionItems);\r\n                        _this.CONSUME(RParen);\r\n                    }\r\n                }\r\n            ]);\r\n        }",
+    definition: [
+      {
+        type: "Alternation",
+        idx: 0,
+        definition: [
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "On",
+                label: "On",
+                idx: 0,
+                pattern: "ON"
+              },
+              {
+                type: "NonTerminal",
+                name: "booleanExpression",
+                idx: 0
+              }
+            ]
+          },
+          {
+            type: "Flat",
+            definition: [
+              {
+                type: "Terminal",
+                name: "Using",
+                label: "Using",
+                idx: 0,
+                pattern: "USING"
+              },
+              {
+                type: "Terminal",
+                name: "LParen",
+                label: "LParen",
+                idx: 0,
+                pattern: "\\("
+              },
+              {
+                type: "NonTerminal",
+                name: "projectionItems",
+                idx: 0
+              },
+              {
+                type: "Terminal",
+                name: "RParen",
+                label: "RParen",
+                idx: 0,
+                pattern: "\\)"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     type: "Rule",

--- a/src/utils/prettifyCst.test.ts
+++ b/src/utils/prettifyCst.test.ts
@@ -6,22 +6,22 @@ describe("formatCst", () => {
       'query(values(Values("VALUES")expression(IntegerValue("2"))expression(IntegerValue("3"))Comma(",")))';
 
     expect(formatCst(prettifiedCst)).toMatchInlineSnapshot(`
-            "query(
-              values(
-                Values(\\"VALUES\\")
-                expression(
-                  IntegerValue(\\"2\\")
-                )
-                expression(
-                  IntegerValue(\\"3\\")
-                )
-                Comma(\\",\\")
-              )
-            )"
-        `);
+                                    "query(
+                                      values(
+                                        Values(\\"VALUES\\")
+                                        expression(
+                                          IntegerValue(\\"2\\")
+                                        )
+                                        expression(
+                                          IntegerValue(\\"3\\")
+                                        )
+                                        Comma(\\",\\")
+                                      )
+                                    )"
+                        `);
   });
 
-  it("should format a multine cst", () => {
+  it("should format a multiline cst", () => {
     const prettifiedCst = `query(
       select(
         Select("SELECT")
@@ -40,26 +40,33 @@ describe("formatCst", () => {
     )`;
 
     expect(formatCst(prettifiedCst)).toMatchInlineSnapshot(`
-      "query(
-        select(
-          Select(\\"SELECT\\")
-          projectionItems(
-            projectionItem(
-              Asterisk(\\"*\\")
-            )
-          )
-          From(\\"FROM\\")
-          tableExpression(
-            tableReference(
-              tablePrimary(
-                Identifier(\\"my_db\\")
-              )
-              As(\\"AS\\")
-              Identifier(\\"plop\\")
-            )
-          )
-        )
-      )"
-    `);
+                              "query(
+                                select(
+                                  Select(\\"SELECT\\")
+                                  projectionItems(
+                                    projectionItem(
+                                      Asterisk(\\"*\\")
+                                    )
+                                  )
+                                  From(\\"FROM\\")
+                                  tableExpression(
+                                    tableReference(
+                                      tablePrimary(
+                                        Identifier(\\"my_db\\")
+                                      )
+                                      As(\\"AS\\")
+                                      Identifier(\\"plop\\")
+                                    )
+                                  )
+                                )
+                              )"
+                    `);
+  });
+
+  it("should deal with escaped values", () => {
+    const prettifiedCst = `Identifier(""foodmart"",""employee_closure"")`;
+    expect(formatCst(prettifiedCst)).toMatchInlineSnapshot(
+      `"Identifier(\\"\\"foodmart\\"\\", \\"\\"employee_closure\\"\\")"`
+    );
   });
 });

--- a/src/visitors/FilterTreeVisitor.ts
+++ b/src/visitors/FilterTreeVisitor.ts
@@ -12,7 +12,8 @@ import {
 import {
   hasColumnPrimary,
   isBinaryOperation,
-  isMultivalOperation
+  isMultivalOperation,
+  isUnaryOperation
 } from "../utils/booleanExpressionValue";
 
 const Visitor = parser.getBaseCstVisitorConstructorWithDefaults();
@@ -35,10 +36,10 @@ export class FilterTreeVisitor extends Visitor {
     if (isMultivalOperation(expressionValue)) {
       return expressionValue.MultivalOperator[0].image.toLowerCase() as Operator;
     }
-    if (expressionValue.IsNotNull) {
+    if (isUnaryOperation(expressionValue) && expressionValue.IsNotNull) {
       return expressionValue.IsNotNull[0].image.toLowerCase() as Operator;
     }
-    if (expressionValue.IsNull) {
+    if (isUnaryOperation(expressionValue) && expressionValue.IsNull) {
       return expressionValue.IsNull[0].image.toLowerCase() as Operator;
     }
 


### PR DESCRIPTION
Finally add the `JOIN` support to our grammar 🎉 

```
tableExpression:
     tableReference [, tableReference ]*
 |   tableExpression [ NATURAL ] [ ( LEFT | RIGHT | FULL ) [ OUTER ] ] JOIN tableExpression [ joinCondition ]
 |   tableExpression CROSS JOIN tableExpression
 |   tableExpression [ CROSS | OUTER ] APPLY tableExpression
```

Did some tests on our existing helpers, everything seams to follow so far 😁 So the `getTablePrimaries` can returns multiples tables!!!

I also discovered a little edge case in my new CST parser (for our unit tests), this is fixed!