### PR TITLE
Add alias support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ $RECYCLE.BIN/
 
 lib
 debug.json
+.yarn

--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,3 @@ $RECYCLE.BIN/
 
 lib
 debug.json
-.yarn

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.1.js

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "hooks": {
       "pre-commit": "pretty-quick --staged"
     }
+  },
+  "prettier": {
+    "trailingComma": "none"
   }
 }

--- a/src/index.projectionItem.test.ts
+++ b/src/index.projectionItem.test.ts
@@ -145,6 +145,24 @@ describe("projectionItem", () => {
 
       expect(query).toEqual("SELECT my_table.column01, column02 FROM my_table");
     });
+    it("should deal with alias", () => {
+      const query = rhombic
+        .parse("SELECT a FROM my_table")
+        .addProjectionItem("column02", { alias: "b" })
+        .toString();
+
+      expect(query).toEqual("SELECT a, column02 AS b FROM my_table");
+    });
+    it("should deal with alias that need to be escaped", () => {
+      const query = rhombic
+        .parse("SELECT a FROM my_table")
+        .addProjectionItem("column02", { alias: "this is second column" })
+        .toString();
+
+      expect(query).toEqual(
+        'SELECT a, column02 AS "this is second column" FROM my_table'
+      );
+    });
   });
 
   describe("updateProjectionItem", () => {

--- a/src/index.projectionItem.test.ts
+++ b/src/index.projectionItem.test.ts
@@ -156,11 +156,13 @@ describe("projectionItem", () => {
     it("should deal with alias that need to be escaped", () => {
       const query = rhombic
         .parse("SELECT a FROM my_table")
-        .addProjectionItem("column02", { alias: "this is second column" })
+        .addProjectionItem("column02", {
+          alias: "I need to be escaped because I have some spaces"
+        })
         .toString();
 
       expect(query).toEqual(
-        'SELECT a, column02 AS "this is second column" FROM my_table'
+        'SELECT a, column02 AS "I need to be escaped because I have some spaces" FROM my_table'
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { fixOrderItem } from "./utils/fixOrderItem";
 import { removeUnusedOrderItems } from "./utils/removeUnusedOrderItems";
 
 // Utils
-export { needToBeEscaped, printFilter, Location };
+export { needToBeEscaped, printFilter };
 
 const rhombic = {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { fixOrderItem } from "./utils/fixOrderItem";
 import { removeUnusedOrderItems } from "./utils/removeUnusedOrderItems";
 
 // Utils
-export { needToBeEscaped, printFilter };
+export { needToBeEscaped, printFilter, Location };
 
 const rhombic = {
   /**
@@ -134,10 +134,15 @@ export interface ParsedSql {
    * @param options
    * @param options.removeAsterisk Remove `*` from the original query (default: `true`)
    * @param options.escapeReservedKeywords Escape reserved keywords (default: `true`)
+   * @param options.alias Provide an alias to the projection item (`AS {alias}`)
    */
   addProjectionItem(
     projectionItem: string,
-    options?: { removeAsterisk?: boolean; escapeReservedKeywords?: boolean }
+    options?: {
+      removeAsterisk?: boolean;
+      escapeReservedKeywords?: boolean;
+      alias?: string;
+    }
   ): ParsedSql;
 
   /**
@@ -276,14 +281,12 @@ const parsedSql = (sql: string): ParsedSql => {
         const sort = visitor.sort.find(
           i => i.expression === (originalValue || value)
         );
-        if (sort) {
-          delete sort.expression; // Remove internal data
-          delete sort.expressionRange; // Remove internal data
-        }
 
         return {
           expression: originalValue || value,
-          sort: sort ? { order: "asc", ...sort } : undefined
+          sort: sort
+            ? { order: sort.order || "asc", nullsOrder: sort.nullsOrder }
+            : undefined
         };
       } else {
         return {
@@ -325,6 +328,13 @@ const parsedSql = (sql: string): ParsedSql => {
         needToBeEscaped(projectionItem)
       ) {
         projectionItem = `"${projectionItem}"`;
+      }
+
+      // add alias
+      if (options.alias) {
+        projectionItem += needToBeEscaped(options.alias)
+          ? ` AS "${options.alias}"`
+          : ` AS ${options.alias}`;
       }
 
       // multiline query


### PR DESCRIPTION
Add `alias` option to `addProjectionItem` helper.

```tsx
const query = rhombic
        .parse("SELECT a FROM my_table")
        .addProjectionItem("column02", { alias: "b" })
        .toString();

      expect(query).toEqual("SELECT a, column02 AS b FROM my_table");
```

This is taking care of escaping the alias if needed.