### PR TITLE
feat(CON-3858): infer columns if table could not be fetched

### DIFF
--- a/src/Lineage.ts
+++ b/src/Lineage.ts
@@ -37,6 +37,7 @@ export interface Edge {
 export interface Column<ColumnData> {
   id: string;
   label: string;
+  isAssumed?: boolean;
   range?: Range;
   data?: ColumnData;
 }

--- a/src/antlr/LineageVisitor.ts
+++ b/src/antlr/LineageVisitor.ts
@@ -3,11 +3,8 @@ import { Edge, Table } from "../Lineage";
 import { QueryStructureVisitor, TableRelation, QueryRelation } from "./QueryStructureVisitor";
 
 export class LineageVisitor<TableData, ColumnData> extends QueryStructureVisitor<void> {
-  //lineage: Lineage<TableData, ColumnData> = [];
-  lineage: {
-    tables: { tablePrimary?: TablePrimary; table: Table<TableData, ColumnData> }[];
-    edges: Edge[];
-  } = { tables: [], edges: [] };
+  tables: { tablePrimary?: TablePrimary; table: Table<TableData, ColumnData> }[] = [];
+  edges: Edge[] = [];
 
   constructor(
     getTable: (
@@ -22,7 +19,7 @@ export class LineageVisitor<TableData, ColumnData> extends QueryStructureVisitor
   //
 
   onColumnReference(tableId: string, columnId?: string): void {
-    this.lineage.edges.push({
+    this.edges.push({
       type: "edge",
       edgeType: this.currentRelation.currentClause,
       source: {
@@ -58,7 +55,7 @@ export class LineageVisitor<TableData, ColumnData> extends QueryStructureVisitor
       tablePrimary = relation.tablePrimary;
     }
 
-    this.lineage.tables.push({
+    this.tables.push({
       tablePrimary,
       table: {
         type: "table",

--- a/src/antlr/LineageVisitor.ts
+++ b/src/antlr/LineageVisitor.ts
@@ -42,7 +42,6 @@ export class LineageVisitor<TableData, ColumnData> extends QueryStructureVisitor
   }
 
   onAssumeReference(tableId: string, columnId: string, columnLabel: string, range: Range): void {
-    console.log("ASSUMED", tableId, columnId);
     const sourceTableId = this.mergedLeaves ? this.deduplicateTables.get(tableId) ?? tableId : tableId;
     const columns = this.unfetchedColumns.get(sourceTableId);
     if (columns !== undefined) {

--- a/src/antlr/QueryStructureVisitor.ts
+++ b/src/antlr/QueryStructureVisitor.ts
@@ -36,7 +36,13 @@ const ROOT_QUERY_ID = "result_1";
 export const ROOT_QUERY_NAME = "[final result]";
 
 export class Column {
-  constructor(readonly id: string, public label: string, readonly range?: Range, readonly data?: unknown) {}
+  constructor(
+    readonly id: string,
+    public label: string,
+    readonly range?: Range,
+    readonly data?: unknown,
+    readonly isAssumed?: boolean
+  ) {}
 }
 
 export abstract class Relation {
@@ -78,18 +84,15 @@ export class TableRelation extends Relation {
     super(id, columns, parent, range);
   }
 
-  resolveColumn(columnName: QuotableIdentifier): ColumnRef | undefined {
-    const colRef = super.resolveColumn(columnName);
-    if (!this.isFetched && colRef === undefined) {
-      const column = {
-        id: `column_${this.columns.length + 1}`,
-        label: columnName.name
-      };
-      this.columns.push(column);
-      return { tableId: this.id, columnId: column.id, isAssumed: true };
-    } else {
-      return colRef;
-    }
+  addAssumedColumn(columnName: QuotableIdentifier, range: Range): ColumnRef {
+    const column = {
+      id: `column_${this.columns.length + 1}`,
+      label: columnName.name,
+      range: range,
+      isAssumed: true
+    };
+    this.columns.push(column);
+    return { tableId: this.id, columnId: column.id, isAssumed: true };
   }
 }
 
@@ -149,18 +152,37 @@ export class QueryRelation extends Relation {
     return this.parent?.findCTE(tableName);
   }
 
-  resolveRelationColumn(columnName: QuotableIdentifier, tableName?: QuotableIdentifier): ColumnRef | undefined {
+  resolveOrAssumeRelationColumn(
+    columnName: QuotableIdentifier,
+    range: Range,
+    tableName?: QuotableIdentifier
+  ): ColumnRef | undefined {
     if (tableName !== undefined) {
-      return this.findRelation(tableName)?.resolveColumn(columnName);
+      const rel = this.findRelation(tableName);
+      const col = rel?.resolveColumn(columnName);
+      if (col === undefined && rel != undefined && rel instanceof TableRelation && !rel.isFetched) {
+        return rel.addAssumedColumn(columnName, range);
+      }
+      return col;
     } else {
+      const unfetched: TableRelation[] = [];
       for (const r of this.relations) {
-        const col = r[1].resolveColumn(columnName);
+        const rel = r[1];
+        const col = rel.resolveColumn(columnName);
         if (col) {
           return col;
         }
+        if (rel instanceof TableRelation && !rel.isFetched) {
+          unfetched.push(rel);
+        }
       }
+
+      if (unfetched.length == 1) {
+        return unfetched[0].addAssumedColumn(columnName, range);
+      }
+
+      return undefined;
     }
-    return undefined;
   }
 
   getNextColumnId(): string {
@@ -248,6 +270,15 @@ export abstract class QueryStructureVisitor<Result> extends AbstractParseTreeVis
     return;
   }
 
+  private reportTableReferences() {
+    for (const entry of this.currentRelation.relations) {
+      const relation = entry[1];
+      if (relation instanceof TableRelation) {
+        this.onRelation(relation, entry[0] !== relation.id ? entry[0] : undefined);
+      }
+    }
+  }
+
   /**
    * Called when column reference is ready.
    * @param _tableId
@@ -255,10 +286,6 @@ export abstract class QueryStructureVisitor<Result> extends AbstractParseTreeVis
    * @returns
    */
   onColumnReference(_tableId: string, _columnId?: string): void {
-    return;
-  }
-
-  onAssumeReference(_tableId: string, _columnId: string, _columnLabel: string, _range: Range): void {
     return;
   }
 
@@ -331,6 +358,8 @@ export abstract class QueryStructureVisitor<Result> extends AbstractParseTreeVis
 
     const result = this.visitChildren(ctx);
 
+    this.reportTableReferences();
+
     // to be consumed later
     this.lastRelation = this.currentRelation;
     if (this.currentRelation.id == ROOT_QUERY_ID) this.onRelation(this.currentRelation, ROOT_QUERY_NAME);
@@ -345,6 +374,7 @@ export abstract class QueryStructureVisitor<Result> extends AbstractParseTreeVis
     // reinit column seq as we will repeat the same columns in subsequent queries
     this.currentRelation.columnIdSeq = 0;
     // clear relations for each queryTermDefault because it's individual query
+    this.reportTableReferences();
     this.currentRelation.relations = new Map();
     return this.visitChildren(ctx);
   }
@@ -449,7 +479,6 @@ export abstract class QueryStructureVisitor<Result> extends AbstractParseTreeVis
     );
 
     this.currentRelation.relations.set(alias, relation);
-    this.onRelation(relation, alias);
 
     return this.defaultResult();
   }
@@ -581,12 +610,10 @@ export abstract class QueryStructureVisitor<Result> extends AbstractParseTreeVis
   private processColumnReference(ctx: ColumnReferenceContext | DereferenceContext): Result {
     const tableCol = this.extractTableAndColumn(ctx);
     if (tableCol !== undefined) {
-      const col = this.currentRelation.resolveRelationColumn(tableCol.column, tableCol.table);
+      const range = this.rangeFromContext(ctx);
+      const col = this.currentRelation.resolveOrAssumeRelationColumn(tableCol.column, range, tableCol.table);
       if (col !== undefined) {
         this.onColumnReference(col.tableId, col.columnId);
-        if (col.isAssumed) {
-          this.onAssumeReference(col.tableId, col.columnId, tableCol.column.name, this.rangeFromContext(ctx));
-        }
       }
       return this.defaultResult();
     } else {

--- a/src/antlr/antlr.test.ts
+++ b/src/antlr/antlr.test.ts
@@ -38,6 +38,10 @@ const columnsMapping: { [tableId: string]: ColumnId[] } = {
 };
 
 const getTable = (table: TablePrimary) => {
+  if (!(table.tableName in columnsMapping)) {
+    return undefined;
+  }
+
   const columnNames = columnsMapping[table.tableName] || [];
   const columns = columnNames.map(columnId => ({
     id: columnId,
@@ -4447,6 +4451,71 @@ describe("antlr", () => {
           source: {
             tableId: "result_3",
             columnId: "currency_id"
+          },
+          target: {
+            tableId: "result_1",
+            columnId: "column_1"
+          }
+        }
+      ]
+    },
+    {
+      name: "derive fields for unknown tables",
+      sql: "SELECT a_column FROM a_table",
+      data: [
+        {
+          type: "table",
+          id: "result_2",
+          label: "a_table",
+          range: {
+            startLine: 1,
+            startColumn: 21,
+            endLine: 1,
+            endColumn: 28
+          },
+          columns: [
+            {
+              id: "column_1",
+              label: "a_column",
+              isAssumed: true,
+              range: {
+                startLine: 1,
+                startColumn: 7,
+                endLine: 1,
+                endColumn: 15
+              }
+            }
+          ]
+        },
+        {
+          type: "table",
+          id: "result_1",
+          label: "[final result]",
+          range: {
+            startLine: 1,
+            startColumn: 0,
+            endLine: 1,
+            endColumn: 28
+          },
+          columns: [
+            {
+              id: "column_1",
+              label: "a_column",
+              range: {
+                startLine: 1,
+                startColumn: 7,
+                endLine: 1,
+                endColumn: 15
+              }
+            }
+          ]
+        },
+        {
+          type: "edge",
+          edgeType: "select",
+          source: {
+            tableId: "result_2",
+            columnId: "column_1"
           },
           target: {
             tableId: "result_1",

--- a/src/antlr/antlr.test.ts
+++ b/src/antlr/antlr.test.ts
@@ -4783,11 +4783,7 @@ describe("antlr", () => {
     }
   }
 
-  cases.forEach(({ data, name, only, sql, debug, mergedLeaves }, idx) => {
-    if (idx === -cases.length - 5) {
-      return;
-    }
-
+  cases.forEach(({ data, name, only, sql, debug, mergedLeaves }) => {
     (only ? it.only : it)(`should parse ${name}`, () => {
       const lineage = antlr.parse(sql, { doubleQuotedIdentifier: true }).getLineage(getTable, mergedLeaves);
       if (debug) {

--- a/src/antlr/common.ts
+++ b/src/antlr/common.ts
@@ -1,7 +1,7 @@
 import { TablePrimary } from "..";
 import { IdentifierContext, QuotedIdentifierAlternativeContext, StrictIdentifierContext } from "./SqlBaseParser";
 
-export type ColumnRef = { tableId: string; columnId: string };
+export type ColumnRef = { tableId: string; columnId: string; isAssumed: boolean };
 
 export type QuotableIdentifier = { name: string; quoted: boolean };
 

--- a/src/antlr/index.ts
+++ b/src/antlr/index.ts
@@ -27,7 +27,8 @@ class SqlParseTree {
   ): Lineage<TableData, ColumnData> {
     const visitor = new LineageVisitor<TableData, ColumnData>(getTable);
     this.tree.accept(visitor);
-    let { tables, edges } = visitor.lineage;
+    const tables = visitor.tables;
+    const edges = visitor.edges;
 
     const cleanedTables: Table<TableData, ColumnData>[] = [];
 

--- a/src/antlr/index.ts
+++ b/src/antlr/index.ts
@@ -1,5 +1,5 @@
 import { CharStreams, CommonTokenStream } from "antlr4ts";
-import { Lineage } from "../Lineage";
+import { Lineage, Table } from "../Lineage";
 import { SqlBaseLexer } from "./SqlBaseLexer";
 import { SqlBaseParser, StatementContext } from "./SqlBaseParser";
 import { UppercaseCharStream } from "./UppercaseCharStream";
@@ -25,18 +25,44 @@ class SqlParseTree {
     ) => { table: { id: string; data: TableData }; columns: { id: string; data: ColumnData }[] } | undefined,
     mergedLeaves?: boolean
   ): Lineage<TableData, ColumnData> {
-    const visitor = new LineageVisitor<TableData, ColumnData>(getTable, mergedLeaves);
+    const visitor = new LineageVisitor<TableData, ColumnData>(getTable);
     this.tree.accept(visitor);
-    const lineage = visitor.lineage;
-    const tables: Lineage<TableData, ColumnData> = [];
-    const edges: Lineage<TableData, ColumnData> = [];
-    const usedColumns: Map<string, string[]> = new Map();
-    lineage.forEach(e => {
-      if (e.type == "table") {
-        tables.push(e);
-      } else {
-        if (mergedLeaves && e.source.columnId !== undefined) {
-          // used column filtering preparation
+    let { tables, edges } = visitor.lineage;
+
+    const cleanedTables: Table<TableData, ColumnData>[] = [];
+
+    // do lineage cleanup if mergedLeaves is true
+    if (mergedLeaves) {
+      // 1. remove duplicate table references from the list of tables
+      const deduplicateTable: Map<string, string> = new Map();
+      const usedTables: Map<string, string> = new Map();
+
+      tables.forEach(t => {
+        if (t.tablePrimary === undefined) {
+          cleanedTables.push(t.table);
+          return;
+        }
+
+        const key = JSON.stringify(t.tablePrimary);
+        const entry = usedTables.get(key);
+        if (entry !== undefined) {
+          deduplicateTable.set(t.table.id, entry);
+        } else {
+          usedTables.set(key, t.table.id);
+          t.table.label = t.tablePrimary.tableName;
+          cleanedTables.push(t.table);
+        }
+      });
+
+      // 2. remove references to duplicate tables from edges and collect used columns of tables
+      const usedColumns: Map<string, string[]> = new Map();
+
+      edges.forEach(e => {
+        const remappedSourceTable = deduplicateTable.get(e.source.tableId);
+        if (remappedSourceTable !== undefined) {
+          e.source.tableId = remappedSourceTable;
+        }
+        if (e.source.columnId !== undefined) {
           const columns = usedColumns.get(e.source.tableId);
           if (columns !== undefined) {
             columns.push(e.source.columnId);
@@ -44,21 +70,20 @@ class SqlParseTree {
             usedColumns.set(e.source.tableId, [e.source.columnId]);
           }
         }
-        edges.push(e);
-      }
-    });
+      });
 
-    tables.forEach(e => {
-      if (e.type == "table") {
-        if (mergedLeaves && e.data !== undefined) {
-          // used column filtering
-          const tableColumns = usedColumns.get(e.id);
-          e.columns = e.columns.filter(c => tableColumns?.includes(c.id));
+      // 3. leave only columns that are used in tables
+      cleanedTables.forEach(t => {
+        if (t.data !== undefined) {
+          const tableColumns = usedColumns.get(t.id);
+          t.columns = t.columns.filter(c => tableColumns?.includes(c.id));
         }
-      }
-    });
+      });
+    } else {
+      tables.forEach(t => cleanedTables.push(t.table));
+    }
 
-    return tables.concat(edges);
+    return ([] as Lineage<TableData, ColumnData>).concat(cleanedTables, edges);
   }
 }
 


### PR DESCRIPTION
# Description

In this pr we extend the lineage visitor to be more lenient in the case where columns of a table could not be fetched. The visitor will then assume columns by usage, i.e. if a column from such a table is selected it is assumed to be part of that table. Additionally, a flag is set on such columns to allow the ui to mark them appropriately.

# Implementation

The `QueryStructureVisitor` is changed to mark tables that could not be resolved via `getTables()` and to add columns, that cannot otherwise be resolved, to such tables, if appropriate. This change means, that column lists of tables can change even after table discovery. To make sure we only report tables when no more changes can happen, the respective `onRelation` calls are delayed until the whole (sub-)query has been processed.

The merge-leaves-logic has been updated to account to tables being reported _after_ column references.