### PR TITLE
Add workflow to check PR description length

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -4,7 +4,11 @@ name: Pull Request description
 
 on:
   pull_request:
-    branches: [ master ]
+    types:
+      # Check title when opened.
+      - opened
+      # When the title or description change
+      - edited
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a workflow to fail CI if no pull-request description is provided 😇 