### PR TITLE
feat(CON-3971): Allow assumed columns in existing catalog tables

### DIFF
--- a/src/antlr/QueryStructureVisitor.ts
+++ b/src/antlr/QueryStructureVisitor.ts
@@ -186,25 +186,28 @@ export class QueryRelation extends Relation {
     if (tableName !== undefined) {
       const rel = this.findRelation(tableName);
       const col = rel?.resolveColumn(columnName);
-      if (col === undefined && rel != undefined && rel instanceof TableRelation && !rel.isFetched) {
+      if (col === undefined && rel != undefined && rel instanceof TableRelation) {
         return rel.addAssumedColumn(columnName, range);
       }
       return col;
     } else {
-      const unfetched: TableRelation[] = [];
+      const tables: TableRelation[] = [];
       for (const r of this.relations) {
         const rel = r[1];
         const col = rel.resolveColumn(columnName);
         if (col) {
           return col;
         }
-        if (rel instanceof TableRelation && !rel.isFetched) {
-          unfetched.push(rel);
+        if (rel instanceof TableRelation) {
+          tables.push(rel);
         }
       }
 
-      if (unfetched.length == 1) {
-        return unfetched[0].addAssumedColumn(columnName, range);
+      const assumed = tables.filter(t => !t.isFetched);
+      if (assumed.length == 1) {
+        return assumed[0].addAssumedColumn(columnName, range);
+      } else if (tables.length == 1) {
+        return tables[0].addAssumedColumn(columnName, range);
       }
 
       return undefined;

--- a/src/antlr/lineage.tests/assumed columns on existing table.json
+++ b/src/antlr/lineage.tests/assumed columns on existing table.json
@@ -1,6 +1,4 @@
 {
-  "debug": true,
-  "only": true,
   "sql": "SELECT account_id aid, account_details adet FROM account",
   "mergedLeaves": true,
   "data": [
@@ -11,22 +9,14 @@
       "range": {
         "startLine": 1,
         "endLine": 1,
-        "startColumn": 46,
-        "endColumn": 53
+        "startColumn": 49,
+        "endColumn": 56
       },
       "data": {
         "id": "account"
       },
       "isSourceOnly": true,
       "columns": [
-        {
-          "id": "account_type",
-          "label": "account_type",
-          "data": {
-            "id": "account_type",
-            "tableId": "account"
-          }
-        },
         {
           "id": "account_id",
           "label": "account_id",
@@ -36,28 +26,15 @@
           }
         },
         {
-          "id": "account_description",
-          "label": "account_description",
-          "data": {
-            "id": "account_description",
-            "tableId": "account"
-          }
-        },
-        {
-          "id": "account_parent",
-          "label": "account_parent",
-          "data": {
-            "id": "account_parent",
-            "tableId": "account"
-          }
-        },
-        {
-          "id": "account_rollup",
-          "label": "account_rollup",
-          "data": {
-            "id": "account_rollup",
-            "tableId": "account"
-          }
+          "id": "column_6",
+          "label": "account_details",
+          "range": {
+            "startLine": 1,
+            "endLine": 1,
+            "startColumn": 23,
+            "endColumn": 38
+          },
+          "isAssumed": true
         }
       ]
     },
@@ -69,7 +46,7 @@
         "startLine": 1,
         "endLine": 1,
         "startColumn": 0,
-        "endColumn": 86
+        "endColumn": 56
       },
       "columns": [
         {
@@ -84,12 +61,12 @@
         },
         {
           "id": "column_2",
-          "label": "ap",
+          "label": "adet",
           "range": {
             "startLine": 1,
             "endLine": 1,
             "startColumn": 23,
-            "endColumn": 40
+            "endColumn": 43
           }
         }
       ],
@@ -112,55 +89,11 @@
       "edgeType": "select",
       "source": {
         "tableId": "result_2",
-        "columnId": "account_parent"
+        "columnId": "column_6"
       },
       "target": {
         "tableId": "result_1",
         "columnId": "column_2"
-      }
-    },
-    {
-      "type": "edge",
-      "edgeType": "group by",
-      "source": {
-        "tableId": "result_2",
-        "columnId": "account_parent"
-      },
-      "target": {
-        "tableId": "result_1"
-      }
-    },
-    {
-      "type": "edge",
-      "edgeType": "group by",
-      "source": {
-        "tableId": "result_2",
-        "columnId": "account_id"
-      },
-      "target": {
-        "tableId": "result_1"
-      }
-    },
-    {
-      "type": "edge",
-      "edgeType": "order by",
-      "source": {
-        "tableId": "result_2",
-        "columnId": "account_parent"
-      },
-      "target": {
-        "tableId": "result_1"
-      }
-    },
-    {
-      "type": "edge",
-      "edgeType": "order by",
-      "source": {
-        "tableId": "result_2",
-        "columnId": "account_id"
-      },
-      "target": {
-        "tableId": "result_1"
       }
     }
   ]

--- a/src/antlr/lineage.tests/assumed columns on existing table.json
+++ b/src/antlr/lineage.tests/assumed columns on existing table.json
@@ -1,0 +1,167 @@
+{
+  "debug": true,
+  "only": true,
+  "sql": "SELECT account_id aid, account_details adet FROM account",
+  "mergedLeaves": true,
+  "data": [
+    {
+      "type": "table",
+      "id": "result_2",
+      "label": "account",
+      "range": {
+        "startLine": 1,
+        "endLine": 1,
+        "startColumn": 46,
+        "endColumn": 53
+      },
+      "data": {
+        "id": "account"
+      },
+      "isSourceOnly": true,
+      "columns": [
+        {
+          "id": "account_type",
+          "label": "account_type",
+          "data": {
+            "id": "account_type",
+            "tableId": "account"
+          }
+        },
+        {
+          "id": "account_id",
+          "label": "account_id",
+          "data": {
+            "id": "account_id",
+            "tableId": "account"
+          }
+        },
+        {
+          "id": "account_description",
+          "label": "account_description",
+          "data": {
+            "id": "account_description",
+            "tableId": "account"
+          }
+        },
+        {
+          "id": "account_parent",
+          "label": "account_parent",
+          "data": {
+            "id": "account_parent",
+            "tableId": "account"
+          }
+        },
+        {
+          "id": "account_rollup",
+          "label": "account_rollup",
+          "data": {
+            "id": "account_rollup",
+            "tableId": "account"
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "id": "result_1",
+      "label": "[final result]",
+      "range": {
+        "startLine": 1,
+        "endLine": 1,
+        "startColumn": 0,
+        "endColumn": 86
+      },
+      "columns": [
+        {
+          "id": "column_1",
+          "label": "aid",
+          "range": {
+            "startLine": 1,
+            "endLine": 1,
+            "startColumn": 7,
+            "endColumn": 21
+          }
+        },
+        {
+          "id": "column_2",
+          "label": "ap",
+          "range": {
+            "startLine": 1,
+            "endLine": 1,
+            "startColumn": 23,
+            "endColumn": 40
+          }
+        }
+      ],
+      "isTargetOnly": true
+    },
+    {
+      "type": "edge",
+      "edgeType": "select",
+      "source": {
+        "tableId": "result_2",
+        "columnId": "account_id"
+      },
+      "target": {
+        "tableId": "result_1",
+        "columnId": "column_1"
+      }
+    },
+    {
+      "type": "edge",
+      "edgeType": "select",
+      "source": {
+        "tableId": "result_2",
+        "columnId": "account_parent"
+      },
+      "target": {
+        "tableId": "result_1",
+        "columnId": "column_2"
+      }
+    },
+    {
+      "type": "edge",
+      "edgeType": "group by",
+      "source": {
+        "tableId": "result_2",
+        "columnId": "account_parent"
+      },
+      "target": {
+        "tableId": "result_1"
+      }
+    },
+    {
+      "type": "edge",
+      "edgeType": "group by",
+      "source": {
+        "tableId": "result_2",
+        "columnId": "account_id"
+      },
+      "target": {
+        "tableId": "result_1"
+      }
+    },
+    {
+      "type": "edge",
+      "edgeType": "order by",
+      "source": {
+        "tableId": "result_2",
+        "columnId": "account_parent"
+      },
+      "target": {
+        "tableId": "result_1"
+      }
+    },
+    {
+      "type": "edge",
+      "edgeType": "order by",
+      "source": {
+        "tableId": "result_2",
+        "columnId": "account_id"
+      },
+      "target": {
+        "tableId": "result_1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Inferred columns are now allowed on catalog tables in the following cases:
* column explicitly mention table
* table is not explicitly chosen but there is only one catalog table in the query